### PR TITLE
Add unit and integration tests for image handling and legacy migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,273 @@
+# Claude — Bindery
+
+Bindery is an open-source suite for markdown book authoring with **feature parity** across hosts:
+- **VS Code extension** (published to Marketplace) — full-featured IDE integration
+- **Obsidian plugin** — fully-featured Obsidian integration
+- **MCP server** (Claude Desktop, Cursor, etc.) — standalone server for AI assistants
+
+TypeScript throughout. Shared logic in `bindery-merge/` and `bindery-core/`; hosts consume
+the shared libraries and add their own host-specific wiring. Keep implementations in sync.
+
+---
+
+## Repo layout
+
+```
+bindery-core/      ← Shared templates, settings, typography, translations
+  src/
+    templates/     ← AI setup instruction templates (per-host)
+    index.ts       ← exports shared types and helpers
+    settings.ts    ← Bindery workspace settings schema and helpers
+    formatting.ts  ← typography transforms (shared across all hosts)
+    translations.ts ← dialect and glossary management
+
+bindery-merge/     ← Shared merge logic (chapter discovery, export orchestration)
+  src/
+    merge.ts       ← mergeBook() — main export orchestrator (950+ lines)
+    tool-locate.ts ← platform-aware path resolution for pandoc, libreoffice (250+ lines)
+    index.ts       ← barrel exports for public API
+    format.ts      ← typography helpers (used during merge)
+
+vscode-ext/        ← VS Code extension (published to Marketplace)
+  src/
+    extension.ts   ← activation, all host commands, format-on-save handler
+    workspace.ts   ← reads/writes .bindery/settings.json + translations.json
+    merge.ts       ← re-exports from @bindery/merge (pure delegation)
+    format.ts      ← typography transforms via @bindery/core
+    mcp.ts         ← vscode.lm.registerTool registrations + mcp.json writer
+    ai-setup.ts    ← generates per-target instruction files
+  mcp-ts/          ← bundled copy of mcp-ts/out/ (for packaging)
+
+Obsidian-plugin/   ← Obsidian plugin (Community Plugins marketplace)
+  src/
+    main.ts        ← activation, all host commands (feature parity with vscode-ext)
+    workspace.ts   ← Vault I/O, settings management (Obsidian-specific)
+    merge.ts       ← Obsidian-specific wrapper around @bindery/merge
+    ai-setup.ts    ← per-target instruction file generation
+    formatter.ts   ← typography formatting via @bindery/core
+    exporter.ts    ← export orchestration (Obsidian-specific UI)
+
+mcp-ts/            ← Standalone MCP server (Claude Desktop, Cursor, etc.)
+  src/
+    index.ts       ← McpServer entry point, all server.registerTool() calls
+    tools.ts       ← one exported function per tool (pure: root + args → string)
+    registry.ts    ← book registry (--book flags + BINDERY_BOOKS env var)
+    search.ts      ← BM25 index build/load/search + optional Ollama reranking
+    docstore.ts    ← file discovery and chunking
+    format.ts      ← typography (shared with @bindery/core)
+
+mcpb/              ← Claude Desktop extension package (mcpb manifest + bundled server)
+  manifest.json    ← mcpb manifest v0.3 — tools list, user_config, privacy_policies
+  server/          ← bundled output (copy of mcp-ts/out/) — DO NOT hand-edit
+```
+
+---
+
+## MCP server — rules for every tool change
+
+The MCP server is published to the Anthropic MCPB directory. These rules are hard requirements to stay publishable.
+
+### Every tool MUST have the correct annotations
+Readonly/destructive are mutually exclusive categories that determine how the tool is presented to users and whether it can be called by read-only agents. Every tool MUST have exactly one of these annotations:
+```typescript
+annotations: { readOnlyHint: true }    // reads only — never writes files
+annotations: { destructiveHint: true } // writes, creates, or modifies files
+```
+Tools that call external tools/api (eg Ollama) should be annotated with the openWorldHint, but this is required for MCPB submission in addition to one of the above, eg a readonly tool that calls an external search API would have:
+```typescript
+annotations: { readOnlyHint: true, openWorldHint: true }     // reads only — never writes files, calls external API or tool
+```
+
+No annotation = mcpb submission rejection. 
+
+| Tool behavior | Annotation |
+|---|---|
+| list, get, read, search, status checks | `readOnlyHint: true` |
+| write, append, overwrite, format, commit, create | `destructiveHint: true` |
+| calls external API or tool (eg search API) | `openWorldHint: true` (in addition to one of the above) |
+
+### Adding a new tool — checklist
+When adding a tool, touch **all five** of these: missing any breaks one surface.
+
+1. **`mcp-ts/src/tools.ts`** — add the implementation function (`toolXxx(root, args): string`)
+2. **`mcp-ts/src/index.ts`** — `server.registerTool(...)` with Zod schema, description, and ONE annotation
+3. **`vscode-ext/src/mcp.ts`** — `vscode.lm.registerTool('bindery_xxx', ...)` + add input interface + add to `McpTools`
+4. **`vscode-ext/package.json`** — add entry to `languageModelTools[]` with JSON Schema input
+5. **`mcpb/manifest.json`** — add `{ "name": "xxx", "description": "..." }` to `tools[]`
+
+### mcpb manifest rules
+- `manifest_version` must stay `"0.3"` or higher
+- `privacy_policies` array must contain a valid HTTPS URL — do not remove it
+- `tools[]` is a flat list of `{ name, description }` — one entry per tool, no inputSchema here
+- The `server/` folder is a bundled copy of `mcp-ts/out/` — update it when releasing
+
+---
+
+## MCP tools reference
+
+see `mcp-ts/src/index.ts` for implementation details and input schemas and `mcpb/README.md` for user-facing descriptions.
+
+---
+
+## VS Code extension — key design rules
+
+- **Generic**: no project-specific strings in source (use "Book", not a title)
+- **Host-agnostic logic**: Shared logic lives in `bindery-merge/` and `bindery-core/`; hosts re-export or wrap
+- **Config priority**: `.bindery/settings.json` → host-specific settings → code defaults
+- **Machine paths only in user settings**: `pandocPath`, `libreOfficePath` — never in workspace settings
+- **Substitution tiers**: built-in (from `@bindery/merge`) → user-general → project (`.bindery/translations.json`). Later tiers win.
+- **formatOnSave**: only fires for files inside the configured `storyFolder`
+- **Activation**: `onStartupFinished` (to ensure LM tools register at launch) + `onLanguage:markdown`
+- **Command namespace**: all commands are `bindery.*` — must match in both `package.json` and `extension.ts`
+
+## Authoring commands (feature parity across hosts)
+
+Both VS Code and Obsidian plugins expose these equivalent commands (identical functionality,
+host-specific UI/activation):
+
+| Command | VS Code | Obsidian | Description |
+|---|---|---|---|
+| `bindery.init` | ✅ | ✅ | Create `.bindery/settings.json`, `translations.json`, generated `.bindery/README.md`, and the opinionated Arc / Notes / Characters / SESSION / PREFERENCES / memory scaffold |
+| `bindery.setupAI` | ✅ | ✅ | Generate CLAUDE.md / copilot-instructions.md / skills / AGENTS.md |
+| `bindery.formatDocument` | ✅ | ✅ | Typography formatting (curly quotes, em-dash, ellipsis) |
+| `bindery.formatFolder` | ✅ | ✅ | Recursively format all .md files in a folder |
+| `bindery.mergeMarkdown` | ✅ | ✅ | Merge chapters → .md |
+| `bindery.mergeDocx` | ✅ | ✅ | Merge chapters → .docx (via pandoc) |
+| `bindery.mergeEpub` | ✅ | ✅ | Merge chapters → .epub (via pandoc) |
+| `bindery.mergePdf` | ✅ | ✅ | Merge chapters → .pdf (via pandoc + LibreOffice) |
+| `bindery.mergeAll` | ✅ | ✅ | Merge chapters → all supported formats |
+| `bindery.findProbableUsToUkWords` | ✅ | ✅ | Surface probable US spellings in EN source |
+| `bindery.addDialect` | ✅ | ✅ | Add a dialect substitution rule (auto-applied at export) |
+| `bindery.addTranslation` | ✅ | ✅ | Add a cross-language glossary entry |
+| `bindery.addLanguage` | ✅ | ✅ | Add a new language and scaffold its story folder |
+| `bindery.openTranslations` | ✅ | ✅ | Show path to translations.json (edit in host editor) |
+| `bindery.noteList` / `bindery_note-list` | ✅ | ✅ | List story notes under the configured notes folder |
+| `bindery.noteGet` / `bindery_note-get` | ✅ | ✅ | Read a story note by path |
+| `bindery.noteCreate` / `bindery_note-create` | ✅ | ✅ | Create a story note |
+| `bindery.noteAppend` / `bindery_note-append` | ✅ | ✅ | Append markdown content to a story note |
+| `bindery.characterList` / `bindery_character-list` | ✅ | ✅ | List structured character profiles |
+| `bindery.characterGet` / `bindery_character-get` | ✅ | ✅ | Read a character profile by name |
+| `bindery.characterCreate` / `bindery_character-create` | ✅ | ✅ | Create a character profile and update the character index |
+| `bindery.characterUpdate` / `bindery_character-update` | ✅ | ✅ | Update a character profile and refresh the index row |
+| `bindery.arcList` / `bindery_arc-list` | ✅ | ✅ | List structured arc files |
+| `bindery.arcGet` / `bindery_arc-get` | ✅ | ✅ | Read an arc file by path |
+| `bindery.arcCreate` / `bindery_arc-create` | ✅ | ✅ | Create an arc file and update the arc index |
+| `bindery.arcUpdate` / `bindery_arc-update` | ✅ | ✅ | Update an arc file and refresh the arc index |
+| `bindery.memoryList` / `bindery_memory-list` | ✅ | ✅ | List durable memory files |
+| `bindery.memoryAppend` / `bindery_memory-append` | ✅ | ✅ | Append a dated memory entry |
+| `bindery.memoryCompact` / `bindery_memory-compact` | ✅ | ✅ | Compact a memory file with backup |
+| `bindery.sessionFocusShow` / `bindery_session-focus-show` | ✅ | ✅ | Show working state from SESSION.md (optionally one section) |
+| `bindery.sessionFocusUpdate` / `bindery_session-focus-update` | ✅ | ✅ | Update a neutral SESSION.md section (replace/append) |
+| `bindery.sessionFocusAppendHandoff` / `bindery_session-focus-append-handoff` | ✅ | ✅ | Append a handoff note to SESSION.md |
+| `bindery.inboxProcess` / `bindery_inbox-process` | ✅ | ✅ | Enumerate Notes/Inbox.md items and propose destinations (read-only) |
+| `bindery.inboxResolve` / `bindery_inbox-resolve` | ✅ | ✅ | Remove already-routed inbox items by number |
+| `bindery.registerMcp` | ✅ | — | Write .vscode/mcp.json for Claude/Codex MCP discovery (VS Code-only) |
+| `bindery.showMcpConfig` | — | ✅ | Display MCP configuration snippet (Obsidian-only) |
+
+---
+
+## AI setup (`ai-setup.ts`)
+
+`setupAiFiles()` generates per-target instruction files. Each target is independent.
+
+| Target | Output |
+|---|---|
+| `claude` | `CLAUDE.md` + `.claude/skills/<skill>/SKILL.md` for each selected skill |
+| `copilot` | `.github/copilot-instructions.md` |
+| `cursor` | `.cursor/rules` |
+| `agents` | `AGENTS.md` |
+
+Skills: `review`, `brainstorm`, `memory`, `translate`, `translation-review`, `status`, `continuity`, `read-aloud`, `read-in`, `proof-read`, `plan-beats`, `character-setup`.
+
+The **memory skill** uses `bindery_memory_list` → `bindery_memory_append` → `bindery_memory_compact` for session decisions and `bindery_note_list` / `bindery_note_get` / `bindery_note_create` / `bindery_note_append` for canonical story notes. Do not fall back to `bindery_get_text` + Edit tool for memory or note writes when a structured tool exists.
+
+The split: durable story/project decisions → `bindery_memory_*` (`.bindery/memories/`); ephemeral working state (current focus, next actions, open questions, handoff) → `bindery_session_focus_*` (`SESSION.md`); durable working preferences → `PREFERENCES.md` (user-owned, never tool-written — propose changes instead); rough/unsorted/pasted material → `Notes/Inbox.md`, triaged with `bindery_inbox_process` / `bindery_inbox_resolve` (not memory).
+
+Current authoring-tool boundary: note, character, arc, memory, session-focus, and inbox-triage MCP/LM tools exist and have matching VS Code/Obsidian host command wrappers. `bindery_session_focus_update` only touches neutral SESSION.md sections; `bindery_inbox_process` only proposes and `bindery_inbox_resolve` only removes named items (route confirmed items with the destination tools first).
+
+### AI setup versioning
+`FILE_VERSION_INFO` in `bindery-core/src/templates.ts` is a per-file version table/map (a Record keyed by output path) that controls staleness detection.
+
+- `setupAiFiles()` stamps `.bindery/ai-version.json` with the current version of each file after every run.
+- On extension activation, if `.bindery/settings.json` exists and a stamped version is older than the one in `FILE_VERSION_INFO`, the user is notified and offered an "Update now" button that opens `bindery.setupAI`.
+- **Bump `FILE_VERSION_INFO` for the changed template by 1 whenever it changed significantly** (i.e. existing users should regenerate). Small copy fixes do not require a bump.
+
+---
+
+## Memory system
+
+Memory files live in `.bindery/memories/` inside the book root.
+- `global.md` — cross-chapter decisions
+- `chXX.md` — per-chapter notes (e.g. `ch10.md`)
+- `archive/` — compacted originals (auto-created by `bindery_memory_compact`)
+
+Format of an appended entry (stamped by `bindery_memory_append`, not the caller):
+```
+## Session YYYY-MM-DD — [title]
+[content lines]
+```
+
+---
+
+## Build
+
+```bash
+# Individual packages
+npm run build --workspace=bindery-core        # outputs to bindery-core/out/
+npm run build --workspace=bindery-merge       # outputs to bindery-merge/out/
+npm run compile --workspace=mcp-ts            # outputs to mcp-ts/out/
+npm run compile --workspace=vscode-ext        # outputs to vscode-ext/out/
+npm run compile --workspace=obsidian-plugin   # outputs to obsidian-plugin/out/
+
+# All packages at once
+npm run build  # builds bindery-core, bindery-merge, compiles all others
+
+# Type-check only (no emit)
+npx tsc --noEmit
+
+# Parity guards
+node scripts/check-tool-parity.mjs
+node scripts/check-command-parity.mjs
+```
+
+### Release workflow
+
+**For MCPB (Claude Desktop):**
+1. `npm run build --workspace=mcp-ts`
+2. Copy `mcp-ts/out/` → `mcpb/server/`
+3. Update `mcpb/manifest.json` version
+4. Submit to Anthropic MCPB directory
+
+**For VS Code Marketplace:**
+1. `npm run compile --workspace=vscode-ext`
+2. Bundle mcp-ts into vscode-ext:
+   ```bash
+   mkdir -p vscode-ext/mcp-ts/out
+   npx esbuild mcp-ts/out/tools.js --bundle --platform=node --format=cjs --target=node18 --outfile=vscode-ext/mcp-ts/out/tools.js
+   npx esbuild mcp-ts/out/index.js --bundle --platform=node --format=cjs --target=node18 --outfile=vscode-ext/mcp-ts/out/index.js
+   ```
+3. Package VSIX: `cd vscode-ext && npx @vscode/vsce package`
+4. Upload to Marketplace
+
+**For Obsidian Community Plugins:**
+1. `npm run compile --workspace=obsidian-plugin`
+2. `npm run bundle --workspace=obsidian-plugin` (outputs bundled main.js to `obsidian-plugin/out/`)
+3. Testing: copy `obsidian-plugin/` to Obsidian vault plugins folder:
+   ```
+   ~/.obsidian/plugins/bindery/   (on Linux/macOS)
+   %APPDATA%\\Obsidian\\plugins\\bindery\\  (on Windows)
+   ```
+4. Submit PR to Obsidian Community Plugins repo
+
+# Hygiene rules for generated files
+
+- Keep generated files small and focused.
+- Prefer splitting responsibilities over growing a single file; aim for roughly <= 400 lines per file unless there is a clear reason not to.
+- Test behavior, not just happy paths.
+- Include at least one non-happy-path test for new behavior (for example: invalid input, edge case, failure path, or regression case).
+- Choose test level intentionally:
+  - unit tests for pure logic,
+  - integration tests for tool wiring / file IO / command flows,
+  - end-to-end only when cross-surface behavior must be validated.
+- If full test coverage is not feasible, explicitly document what was not tested and why.
+- When updating packages, always regenerate lock files with the same npm major used by CI so contributors do not create lockfiles that CI cannot read.

--- a/bindery-core/src/formatting.ts
+++ b/bindery-core/src/formatting.ts
@@ -21,11 +21,15 @@ const EM_DASH = '\u{2014}';       // —
 /** Matches HTML comments: <!-- ... --> */
 const COMMENT_RE = /<!--[\s\S]*?-->/g;
 
-/** Matches the target part of a markdown link/image: `](path "title")`. */
-const LINK_TARGET_RE = /\]\([^)\n]*\)/g;
+/**
+ * Matches the target part of a markdown link/image: `](path "title")`.
+ * Supports one level of balanced parentheses inside the target
+ * (e.g. `](assets/a(b)--c.png)`).
+ */
+const LINK_TARGET_RE = /\]\([^()\n]*(?:\([^()\n]*\)[^()\n]*)*\)/g;
 
 /** Matches Obsidian wikilinks and embeds: `[[target]]`, `![[target]]`. */
-const WIKILINK_RE = /!?\[\[[^\]\n]*\]\]/g;
+const WIKILINK_RE = /!?\[\[[^\][\n]*\]\]/g;
 
 /** Matches opening double quote context: after whitespace, line start, or brackets */
 const OPEN_DOUBLE_RE = /(^|[\s([{—–-])"/gm;

--- a/bindery-core/src/formatting.ts
+++ b/bindery-core/src/formatting.ts
@@ -21,6 +21,12 @@ const EM_DASH = '\u{2014}';       // —
 /** Matches HTML comments: <!-- ... --> */
 const COMMENT_RE = /<!--[\s\S]*?-->/g;
 
+/** Matches the target part of a markdown link/image: `](path "title")`. */
+const LINK_TARGET_RE = /\]\([^)\n]*\)/g;
+
+/** Matches Obsidian wikilinks and embeds: `[[target]]`, `![[target]]`. */
+const WIKILINK_RE = /!?\[\[[^\]\n]*\]\]/g;
+
 /** Matches opening double quote context: after whitespace, line start, or brackets */
 const OPEN_DOUBLE_RE = /(^|[\s([{—–-])"/gm;
 
@@ -42,6 +48,17 @@ const CLOSE_DOUBLE_AFTER_EM_DASH_RE = /—"([\s)\].,;:!?]|$)/gm;
  */
 export function updateTypography(text: string): string {
     let result = text;
+
+    // Step 0: Protect link targets and wikilinks — paths must not get
+    // em-dashes, ellipses, or curly quotes (that would break the link).
+    const protectedLinks: string[] = [];
+    const protectLink = (match: string): string => {
+        const placeholder = `\x00LINK${protectedLinks.length}\x00`;
+        protectedLinks.push(match);
+        return placeholder;
+    };
+    result = result.replaceAll(WIKILINK_RE, protectLink);
+    result = result.replaceAll(LINK_TARGET_RE, protectLink);
 
     // Step 1: Convert ... to ellipsis (must happen before quote processing)
     result = result.replaceAll(/\.\.\./g, ELLIPSIS);
@@ -85,6 +102,11 @@ export function updateTypography(text: string): string {
     });
     // Closing/apostrophe: all remaining straight single quotes
     result = result.replaceAll(/'/g, CLOSE_SINGLE);
+
+    // Step 7: Restore link targets and wikilinks
+    for (let i = 0; i < protectedLinks.length; i++) {
+        result = result.replaceAll(`\x00LINK${i}\x00`, protectedLinks[i]);
+    }
 
     return result;
 }

--- a/bindery-core/src/settings.ts
+++ b/bindery-core/src/settings.ts
@@ -21,6 +21,8 @@ export interface LanguageConfig {
     epilogueLabel: string;
     /** True for the primary language the book is written in. */
     isDefault?: boolean;
+    /** Path to this language's cover image, relative to the book root (e.g. "images/EN-cover.jpg"). */
+    coverImage?: string;
     /** Dialect exports derived from this language (e.g. en-gb from EN). No story folder of their own. */
     dialects?: DialectConfig[];
 }
@@ -73,6 +75,14 @@ export interface WorkspaceSettings {
     mergedOutputDir?:  string;
     mergeFilePrefix?: string;
     formatOnSave?:   boolean;
+    /**
+     * Book-level fallback cover image, relative to the book root. Used when a
+     * language has no `coverImage` of its own — handy when one cover design
+     * (without per-language text) applies to every translation.
+     */
+    coverImage?: string;
+    /** Set after the legacy chapterN.jpg → inline image link migration has run (or was declined). */
+    imageLinksMigrated?: boolean;
     languages?:      LanguageConfig[];
     git?: {
         snapshot?: {

--- a/bindery-core/src/templates/agents.ts
+++ b/bindery-core/src/templates/agents.ts
@@ -3,7 +3,7 @@ import { renderAgentTemplate } from './agentRender';
 
 export const meta: TemplateMeta = {
     file:    'AGENTS.md',
-    version: 13,
+    version: 14,
     label:   'agent instructions',
 };
 

--- a/bindery-core/src/templates/bindery-readme.ts
+++ b/bindery-core/src/templates/bindery-readme.ts
@@ -2,7 +2,7 @@ import type { TemplateContext, TemplateMeta } from './context';
 
 export const meta: TemplateMeta = {
     file:    '.bindery/README.md',
-  version: 12,
+  version: 13,
     label:   'bindery capabilities',
 };
 
@@ -150,6 +150,68 @@ work-in-progress and continue on another machine.
 - \`get_review_text(autoStage: true)\` returns marker regions in addition to the
   git diff and **removes** the marker lines as part of staging, so the next
   review pass starts clean.
+
+## Inline images in chapters
+
+Put an image anywhere in a chapter with standard markdown image syntax:
+
+\`\`\`
+![A map of the region](../../Images/map.png)
+\`\`\`
+
+- The path is resolved **relative to the chapter file**, so it renders in VS Code
+  and Obsidian previews exactly as written — what you see in preview is what
+  export produces.
+- At merge time the link is resolved to an absolute path so Pandoc can embed it
+  regardless of where the merged temp file lives; a missing target produces a
+  merge warning instead of a silent 404.
+- **Markdown \`.md\` export is fully portable**: every referenced image is copied
+  into \`Images/\` next to the merged file and links are rewritten to
+  \`Images/<name>.png\`, so \`book.md\` + \`Images/\` can be moved or shared as a unit.
+  DOCX/EPUB/PDF embed images directly (via Pandoc) and need no such folder.
+- Obsidian embed syntax \`![[image.png]]\` only renders inside Obsidian. It is
+  stripped from merged output with a warning — use the markdown syntax above
+  instead (Obsidian's *Files & Links* setting can be switched to "Use \`[markdown\` links" to make this the default when inserting via drag-and-drop).
+- Older Bindery versions inserted \`images/chapterN.jpg\` / \`images/prologue.jpg\`
+  / \`images/epilogue.jpg\` automatically at export. That implicit behavior has
+  been removed in favor of explicit inline links; VS Code and Obsidian offer a
+  one-time migration on activation that inserts links for any legacy image
+  still unreferenced, and merge surfaces a warning for any that remain orphaned.
+
+### Cover images
+
+Cover art is book-level metadata, not chapter content — it becomes the EPUB
+cover-image flag and a full front page in DOCX/PDF, so it is **not** an inline
+\`![]()\` link inside a chapter. Instead, set it explicitly in
+\`.bindery/settings.json\`, at either (or both) of two levels:
+
+\`\`\`json
+{
+  "coverImage": "images/cover.jpg",
+  "languages": [
+    { "code": "EN", "coverImage": "images/EN-cover.jpg", ... },
+    { "code": "NL", ... }
+  ]
+}
+\`\`\`
+
+Resolution order per language: **\`languages[].coverImage\`** (per-language —
+use this when cover art includes translated text) → **top-level
+\`coverImage\`** (a book-level fallback — use this when one cover design is
+shared across every translation, e.g. \`NL\` above with no cover of its own) →
+none.
+
+- Both paths are relative to the book root. Keeping cover art in \`images/\`
+  alongside other art (rather than inside \`Story/<lang>/\`) keeps the story
+  folders free of non-chapter files.
+- \`Bindery: Add Language\` prompts for the per-language path, prefilled with
+  \`images/<CODE>-cover.jpg\`; leave it blank to fall back to the book-level
+  cover (or to have no cover at all if neither is set).
+- Older Bindery versions used a fixed \`Story/<lang>/cover.jpg\` convention. That
+  file is still picked up as a fallback (with a warning) if neither
+  \`coverImage\` setting is present — the same one-time activation migration
+  above also offers to move it to \`images/<code>-cover.jpg\` and write the
+  per-language \`coverImage\` setting for you.
 
 ## Skill workflows (Claude / Copilot Chat / etc.)
 

--- a/bindery-core/src/templates/building-blocks.ts
+++ b/bindery-core/src/templates/building-blocks.ts
@@ -90,6 +90,7 @@ export function pushWritingRules(lines: string[], ctx: TemplateContext): void {
         '- Never rewrite paragraphs unless explicitly asked. Suggest edits only.',
         '- HTML comments `<!-- -->` in chapter files are writer notes. Treat as context, not prose.',
         '- Quotation marks and dashes in chapter files are managed by the Bindery extension. Do not flag these as formatting errors.',
+        '- Inline images use standard markdown image syntax `![alt](relative/path.png)`, resolved relative to the chapter file — this is what renders in host previews and survives export. Do not use Obsidian embed syntax `![[image.png]]`; it only renders inside Obsidian and is stripped (with a warning) at merge time.',
     );
     if (ctx.audience) {
         lines.push(`- Content is aimed at ${ctx.audience}. Keep language accessible and themes age-appropriate.`);

--- a/bindery-core/src/templates/claude.ts
+++ b/bindery-core/src/templates/claude.ts
@@ -3,7 +3,7 @@ import { renderAgentTemplate } from './agentRender';
 
 export const meta: TemplateMeta = {
     file:    'CLAUDE.md',
-    version: 18,
+    version: 19,
     label:   'project instructions',
 };
 

--- a/bindery-core/src/templates/copilot.ts
+++ b/bindery-core/src/templates/copilot.ts
@@ -3,7 +3,7 @@ import { renderAgentTemplate } from './agentRender';
 
 export const meta: TemplateMeta = {
     file:    '.github/copilot-instructions.md',
-    version: 12,
+    version: 13,
     label:   'copilot instructions',
 };
 

--- a/bindery-core/src/templates/cursor.ts
+++ b/bindery-core/src/templates/cursor.ts
@@ -3,7 +3,7 @@ import { renderAgentTemplate } from './agentRender';
 
 export const meta: TemplateMeta = {
     file:    '.cursor/rules',
-    version: 12,
+    version: 13,
     label:   'cursor rules',
 };
 

--- a/bindery-core/test/formatting.test.ts
+++ b/bindery-core/test/formatting.test.ts
@@ -211,6 +211,20 @@ describe('updateTypography()', () => {
         expect(result).toContain('(one--two.png)');
         expect(result).toContain('(three--four.png)');
     });
+
+    it('protects the full target when the path contains balanced parentheses', () => {
+        const input = '![alt](assets/a(b)--c.png) and prose--here';
+        const result = updateTypography(input);
+        expect(result).toContain('(assets/a(b)--c.png)');
+        expect(result).toContain('prose—here');
+    });
+
+    it('does not hang on pathological repeated wikilink openers', () => {
+        const input = '[['.repeat(20000);
+        const start = Date.now();
+        updateTypography(input);
+        expect(Date.now() - start).toBeLessThan(2000);
+    });
 });
 
 describe('applyTypography()', () => {

--- a/bindery-core/test/formatting.test.ts
+++ b/bindery-core/test/formatting.test.ts
@@ -162,6 +162,55 @@ describe('updateTypography()', () => {
         const input = 'Plain text without anything special.';
         expect(updateTypography(input)).toBe(input);
     });
+
+    // ─── Image / link target protection ───────────────────────────────────────
+
+    it('does not corrupt an image path containing double-dashes', () => {
+        const input = '![cover](images/cover--final.png)';
+        expect(updateTypography(input)).toBe(input);
+    });
+
+    it('does not corrupt quotes inside a link title', () => {
+        const input = '![alt](images/map.png "The \'Old\' Map")';
+        expect(updateTypography(input)).toBe(input);
+    });
+
+    it('does not touch a plain markdown link target with special chars', () => {
+        const input = 'See [the doc](notes/plan--v2.md) for details.';
+        const result = updateTypography(input);
+        expect(result).toContain('notes/plan--v2.md');
+        // surrounding prose is still formatted
+        expect(result).toBe('See [the doc](notes/plan--v2.md) for details.');
+    });
+
+    it('formats alt text and surrounding prose while preserving the path', () => {
+        const input = '![a map--legend](images/map.png) "quoted" text';
+        const result = updateTypography(input);
+        expect(result).toContain('(images/map.png)');
+        expect(result).toContain('—legend');
+        expect(result).toContain('“quoted”');
+    });
+
+    it('does not corrupt an Obsidian wikilink embed', () => {
+        const input = 'Before ![[my "vault" pic--v2.png]] after--text';
+        const result = updateTypography(input);
+        expect(result).toContain('![[my "vault" pic--v2.png]]');
+        expect(result).toContain('after—text');
+    });
+
+    it('does not corrupt a plain Obsidian wikilink', () => {
+        const input = "See [[Notes/Plan--v2]] for it's context.";
+        const result = updateTypography(input);
+        expect(result).toContain('[[Notes/Plan--v2]]');
+        expect(result).toContain('it’s');
+    });
+
+    it('handles multiple image links on one line independently', () => {
+        const input = '![a](one--two.png) and ![b](three--four.png)';
+        const result = updateTypography(input);
+        expect(result).toContain('(one--two.png)');
+        expect(result).toContain('(three--four.png)');
+    });
 });
 
 describe('applyTypography()', () => {

--- a/bindery-merge/src/images.ts
+++ b/bindery-merge/src/images.ts
@@ -1,0 +1,235 @@
+/**
+ * Inline image handling for merged output.
+ *
+ * Authors write standard markdown image links (`![alt](relative/path.png)`)
+ * relative to the chapter file, so host previews (VS Code, Obsidian) render
+ * them. At merge time those links are resolved to absolute paths so Pandoc
+ * can embed them regardless of where the merged temp file lives.
+ *
+ * Obsidian wikilink embeds (`![[image.png]]`) only work inside Obsidian and
+ * are stripped from merged output with a warning.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── Regex Patterns ─────────────────────────────────────────────────────────
+
+/** `![alt](target)` with optional "title" — target must not contain spaces or `)`. */
+const IMAGE_LINK_RE = /!\[([^\]]*)\]\(([^)\s]+)(\s+"[^"]*")?\)/g;
+
+/** Obsidian embed: `![[target]]` (images, notes, any vault attachment). */
+const WIKILINK_EMBED_RE = /!\[\[[^\]]*\]\]/g;
+
+/** URL scheme (http:, https:, data:, …) — at least 2 chars so `C:` drive letters do not match. */
+const URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]+:/;
+
+const FENCE_RE = /^\s*(```|~~~)/;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ImageRewriteResult {
+    content: string;
+    /** Human-readable problems found (missing files, stripped wikilinks). */
+    warnings: string[];
+    /** Absolute paths (forward-slash) of all image files referenced after rewriting. */
+    imagePaths: string[];
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function toForwardSlashes(p: string): string {
+    return p.replaceAll('\\', '/');
+}
+
+function isExternalTarget(target: string): boolean {
+    return URL_SCHEME_RE.test(target);
+}
+
+/**
+ * Split text into segments, applying `transform` only to lines outside
+ * fenced code blocks. Preserves original line breaks.
+ */
+function mapOutsideFences(text: string, transform: (line: string) => string): string {
+    const parts = text.split(/(\r?\n)/);
+    const out: string[] = [];
+    let inFence = false;
+
+    for (let i = 0; i < parts.length; i += 2) {
+        const line = parts[i] ?? '';
+        const lineBreak = parts[i + 1] ?? '';
+
+        if (FENCE_RE.test(line)) {
+            inFence = !inFence;
+            out.push(line + lineBreak);
+            continue;
+        }
+
+        out.push((inFence ? line : transform(line)) + lineBreak);
+    }
+
+    return out.join('');
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve relative markdown image links against the source file's directory
+ * and strip Obsidian wikilink embeds.
+ *
+ * - External targets (`http:`, `https:`, `data:`, …) are left untouched.
+ * - Absolute paths are normalized to forward slashes but not relocated.
+ * - Relative paths are resolved against `sourceDir` (matching how VS Code
+ *   and Obsidian previews resolve them).
+ * - Resolved local paths that do not exist produce a warning; the link is
+ *   kept so the author can see the broken reference in the output.
+ * - `![[embed]]` wikilinks are removed with a warning (Obsidian-only syntax).
+ *
+ * `sourceLabel` is used to prefix warnings (e.g. the file's name).
+ */
+export function rewriteImageLinks(
+    content: string,
+    sourceDir: string,
+    sourceLabel: string
+): ImageRewriteResult {
+    const warnings: string[] = [];
+    const imagePaths: string[] = [];
+
+    const result = mapOutsideFences(content, (line) => {
+        let processed = line.replaceAll(WIKILINK_EMBED_RE, (match) => {
+            warnings.push(
+                `${sourceLabel}: removed Obsidian embed ${match} — it only renders inside Obsidian. ` +
+                'Use markdown image syntax instead: ![](path/to/image.png)'
+            );
+            return '';
+        });
+
+        processed = processed.replaceAll(IMAGE_LINK_RE, (match, alt: string, target: string, title: string | undefined) => {
+            if (isExternalTarget(target)) {
+                return match;
+            }
+
+            const resolved = path.isAbsolute(target)
+                ? path.normalize(target)
+                : path.resolve(sourceDir, target);
+            const forward = toForwardSlashes(resolved);
+
+            if (!fs.existsSync(resolved)) {
+                warnings.push(`${sourceLabel}: image not found: ${target} (resolved to ${forward})`);
+            } else {
+                imagePaths.push(forward);
+            }
+
+            return `![${alt}](${forward}${title ?? ''})`;
+        });
+
+        return processed;
+    });
+
+    return { content: result, warnings, imagePaths };
+}
+
+// ─── Portable Markdown Export ───────────────────────────────────────────────
+
+export interface PortableCopyResult {
+    content: string;
+    /** Files copied, as absolute destination paths. */
+    copied: string[];
+    warnings: string[];
+}
+
+/**
+ * Make merged markdown portable: copy every locally-resolved image into
+ * `<outputDir>/Images/` and rewrite links to relative `Images/<name>` paths,
+ * so `book.md` + `Images/` can be moved or shared as a unit.
+ *
+ * Name collisions (same basename, different source file) are resolved by
+ * suffixing: `map.png`, `map-2.png`, …. The same source path always maps to
+ * the same destination.
+ */
+export function makePortableMarkdown(
+    content: string,
+    outputDir: string,
+    imagesFolderName = 'Images'
+): PortableCopyResult {
+    const warnings: string[] = [];
+    const copied: string[] = [];
+    const sourceToDest = new Map<string, string>();   // absolute source → dest basename
+    const usedNames = new Map<string, string>();      // dest basename (lowercase) → source it belongs to
+
+    function destNameFor(absSource: string): string {
+        const existing = sourceToDest.get(absSource);
+        if (existing) { return existing; }
+
+        const ext = path.extname(absSource);
+        const stem = path.basename(absSource, ext);
+        let candidate = `${stem}${ext}`;
+        let counter = 2;
+        while (usedNames.has(candidate.toLowerCase()) && usedNames.get(candidate.toLowerCase()) !== absSource) {
+            candidate = `${stem}-${counter}${ext}`;
+            counter++;
+        }
+
+        usedNames.set(candidate.toLowerCase(), absSource);
+        sourceToDest.set(absSource, candidate);
+        return candidate;
+    }
+
+    const imagesDir = path.join(outputDir, imagesFolderName);
+    let imagesDirCreated = fs.existsSync(imagesDir);
+
+    const result = mapOutsideFences(content, (line) =>
+        line.replaceAll(IMAGE_LINK_RE, (match, alt: string, target: string, title: string | undefined) => {
+            if (isExternalTarget(target) || !path.isAbsolute(target)) {
+                return match;
+            }
+
+            const absSource = path.normalize(target);
+            if (!fs.existsSync(absSource)) {
+                // Missing images were already reported during rewriting; leave the link as-is.
+                return match;
+            }
+
+            const destName = destNameFor(absSource);
+            const destPath = path.join(imagesDir, destName);
+
+            if (!copied.includes(destPath)) {
+                try {
+                    if (!imagesDirCreated) {
+                        fs.mkdirSync(imagesDir, { recursive: true });
+                        imagesDirCreated = true;
+                    }
+                    fs.copyFileSync(absSource, destPath);
+                    copied.push(destPath);
+                } catch (err: unknown) {
+                    warnings.push(
+                        `Failed to copy image ${toForwardSlashes(absSource)} to ${toForwardSlashes(destPath)}: ` +
+                        (err instanceof Error ? err.message : String(err))
+                    );
+                    return match;
+                }
+            }
+
+            return `![${alt}](${imagesFolderName}/${destName}${title ?? ''})`;
+        })
+    );
+
+    return { content: result, copied, warnings };
+}
+
+// ─── Legacy chapterN images ─────────────────────────────────────────────────
+
+/** Legacy implicit image name for a merge file kind, or undefined if none applies. */
+export function legacyImageName(kind: 'prologue' | 'epilogue' | 'chapter', chapterNum?: number): string {
+    switch (kind) {
+        case 'prologue': return 'prologue.jpg';
+        case 'epilogue': return 'epilogue.jpg';
+        case 'chapter': return `chapter${chapterNum}.jpg`;
+    }
+}
+
+/** True if the content already references any markdown image link. */
+export function hasImageLink(content: string): boolean {
+    IMAGE_LINK_RE.lastIndex = 0;
+    return IMAGE_LINK_RE.test(content);
+}

--- a/bindery-merge/src/images.ts
+++ b/bindery-merge/src/images.ts
@@ -15,11 +15,11 @@ import * as path from 'node:path';
 
 // ─── Regex Patterns ─────────────────────────────────────────────────────────
 
-/** `![alt](target)` with optional "title" — target must not contain spaces or `)`. */
-const IMAGE_LINK_RE = /!\[([^\]]*)\]\(([^)\s]+)(\s+"[^"]*")?\)/g;
+/** `![alt](target)` with optional "title" — target must not contain spaces or parentheses. */
+const IMAGE_LINK_RE = /!\[([^\][]*)\]\(([^()\s]+)(\s+"[^"]*")?\)/g;
 
 /** Obsidian embed: `![[target]]` (images, notes, any vault attachment). */
-const WIKILINK_EMBED_RE = /!\[\[[^\]]*\]\]/g;
+const WIKILINK_EMBED_RE = /!\[\[[^\][]*\]\]/g;
 
 /** URL scheme (http:, https:, data:, …) — at least 2 chars so `C:` drive letters do not match. */
 const URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]+:/;
@@ -154,6 +154,7 @@ export function makePortableMarkdown(
 ): PortableCopyResult {
     const warnings: string[] = [];
     const copied: string[] = [];
+    const copiedSet = new Set<string>();              // absolute dest paths already copied
     const sourceToDest = new Map<string, string>();   // absolute source → dest basename
     const usedNames = new Map<string, string>();      // dest basename (lowercase) → source it belongs to
 
@@ -193,13 +194,14 @@ export function makePortableMarkdown(
             const destName = destNameFor(absSource);
             const destPath = path.join(imagesDir, destName);
 
-            if (!copied.includes(destPath)) {
+            if (!copiedSet.has(destPath)) {
                 try {
                     if (!imagesDirCreated) {
                         fs.mkdirSync(imagesDir, { recursive: true });
                         imagesDirCreated = true;
                     }
                     fs.copyFileSync(absSource, destPath);
+                    copiedSet.add(destPath);
                     copied.push(destPath);
                 } catch (err: unknown) {
                     warnings.push(

--- a/bindery-merge/src/index.ts
+++ b/bindery-merge/src/index.ts
@@ -11,11 +11,13 @@ export {
     type OutputType,
     type MergeOptions,
     type MergeResult,
+    type CoverResolution,
     mergeBook,
     checkPandoc,
     getPandocOutputFormats,
     clearPandocCapabilityCache,
     getBuiltInUkReplacements,
+    resolveCoverImage,
 } from './merge.js';
 
 export {
@@ -24,3 +26,20 @@ export {
     locateToolPath,
     clearLocateCache,
 } from './tool-locate.js';
+
+export {
+    type ImageRewriteResult,
+    type PortableCopyResult,
+    rewriteImageLinks,
+    makePortableMarkdown,
+    hasImageLink,
+} from './images.js';
+
+export {
+    type LegacyImageProposal,
+    type LegacyCoverProposal,
+    proposeLegacyImageMigration,
+    applyLegacyImageMigration,
+    proposeLegacyCoverMigration,
+    applyLegacyCoverMigration,
+} from './legacy-images.js';

--- a/bindery-merge/src/legacy-images.ts
+++ b/bindery-merge/src/legacy-images.ts
@@ -1,0 +1,158 @@
+/**
+ * One-time migration from implicit chapter images (images/chapterN.jpg,
+ * prologue.jpg, epilogue.jpg — injected at merge time in older Bindery
+ * versions) to explicit inline markdown image links in the chapter files.
+ *
+ * Pure scan/apply split: hosts (VS Code, Obsidian) own the prompt UI and
+ * call `proposeLegacyImageMigration` on activation, then
+ * `applyLegacyImageMigration` if the user accepts.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { LanguageConfig } from '@bindery/core';
+import { getOrderedFiles } from './merge.js';
+import { legacyImageName, hasImageLink } from './images.js';
+
+const HEADING_LINE_RE = /^#[^\n]*\n/m;
+
+export interface LegacyImageProposal {
+    /** Absolute path of the chapter/prologue/epilogue markdown file. */
+    filePath: string;
+    /** Absolute path of the legacy image that is not referenced by the file. */
+    imagePath: string;
+    /** Relative image link (forward slashes) to insert, resolvable from the file's folder. */
+    relativeLink: string;
+}
+
+/**
+ * Scan one language folder for legacy images that exist on disk but are not
+ * referenced by an inline image link in the corresponding markdown file.
+ * Returns one proposal per affected file; empty array means nothing to migrate.
+ */
+export function proposeLegacyImageMigration(
+    root: string,
+    storyFolder: string,
+    language: LanguageConfig
+): LegacyImageProposal[] {
+    const langPath = path.join(root, storyFolder, language.folderName);
+    if (!fs.existsSync(langPath)) { return []; }
+
+    const proposals: LegacyImageProposal[] = [];
+
+    for (const file of getOrderedFiles(langPath, language)) {
+        const kind = file.fileType.kind;
+        if (kind === 'act') { continue; }
+
+        const name = legacyImageName(kind, kind === 'chapter' ? file.fileType.num : undefined);
+        const imagePath = path.join(root, 'images', name);
+        if (!fs.existsSync(imagePath)) { continue; }
+
+        const content = fs.readFileSync(file.filePath, 'utf-8');
+        if (hasImageLink(content)) { continue; }
+
+        const relativeLink = path
+            .relative(path.dirname(file.filePath), imagePath)
+            .replaceAll('\\', '/');
+        proposals.push({ filePath: file.filePath, imagePath, relativeLink });
+    }
+
+    return proposals;
+}
+
+/**
+ * Insert `![](relativeLink)` after the first heading of each proposed file
+ * (or at the top when the file has no heading). Skips files that gained an
+ * image link since the scan. Returns the number of files changed.
+ */
+export function applyLegacyImageMigration(proposals: LegacyImageProposal[]): number {
+    let changed = 0;
+
+    for (const proposal of proposals) {
+        if (!fs.existsSync(proposal.filePath)) { continue; }
+        const content = fs.readFileSync(proposal.filePath, 'utf-8');
+        if (hasImageLink(content)) { continue; }
+
+        const m = HEADING_LINE_RE.exec(content);
+        const updated = m
+            ? content.substring(0, m.index + m[0].length) + `\n![](${proposal.relativeLink})\n` + content.substring(m.index + m[0].length)
+            : `![](${proposal.relativeLink})\n\n` + content;
+
+        fs.writeFileSync(proposal.filePath, updated, 'utf-8');
+        changed++;
+    }
+
+    return changed;
+}
+
+// ─── Legacy cover.jpg migration ─────────────────────────────────────────────
+//
+// Older Bindery versions relied on a fixed `<storyFolder>/<langFolder>/cover.jpg`
+// convention. Covers are book-level metadata (epub cover flag, docx/pdf front
+// page) rather than chapter content, so they migrate into the shared images/
+// folder as `<code>-cover.jpg` and become an explicit `coverImage` setting
+// instead of a second filename convention.
+
+export interface LegacyCoverProposal {
+    languageCode: string;
+    /** Absolute path of the legacy cover.jpg file. */
+    oldPath: string;
+    /** New location relative to the book root, forward slashes (e.g. "images/EN-cover.jpg"). */
+    newRelativePath: string;
+}
+
+/**
+ * Scan configured languages for a legacy `<storyFolder>/<langFolder>/cover.jpg`
+ * where `coverImage` is not already set in settings. Reuses the same single
+ * activation scan as `proposeLegacyImageMigration` — callers should present
+ * both proposal lists in one combined prompt rather than scanning twice.
+ */
+export function proposeLegacyCoverMigration(
+    root: string,
+    storyFolder: string,
+    languages: LanguageConfig[]
+): LegacyCoverProposal[] {
+    const proposals: LegacyCoverProposal[] = [];
+
+    for (const lang of languages) {
+        if (lang.coverImage?.trim()) { continue; }
+
+        const oldPath = path.join(root, storyFolder, lang.folderName, 'cover.jpg');
+        if (!fs.existsSync(oldPath)) { continue; }
+
+        proposals.push({
+            languageCode: lang.code,
+            oldPath,
+            newRelativePath: `images/${lang.code}-cover.jpg`,
+        });
+    }
+
+    return proposals;
+}
+
+/**
+ * Moves each proposed cover into the shared images/ folder. Does not
+ * overwrite an existing destination file. Returns the new relative path per
+ * language code so the caller can merge it into `languages[].coverImage`
+ * and write settings.json once.
+ */
+export function applyLegacyCoverMigration(root: string, proposals: LegacyCoverProposal[]): Map<string, string> {
+    const applied = new Map<string, string>();
+
+    for (const proposal of proposals) {
+        if (!fs.existsSync(proposal.oldPath)) { continue; }
+        const destPath = path.join(root, proposal.newRelativePath);
+        if (fs.existsSync(destPath)) { continue; }
+
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        try {
+            fs.renameSync(proposal.oldPath, destPath);
+        } catch {
+            fs.copyFileSync(proposal.oldPath, destPath);
+            fs.unlinkSync(proposal.oldPath);
+        }
+        applied.set(proposal.languageCode, proposal.newRelativePath);
+    }
+
+    return applied;
+}

--- a/bindery-merge/src/merge.ts
+++ b/bindery-merge/src/merge.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path';
 import * as cp from 'node:child_process';
 import { updateTypography } from '@bindery/core';
 import type { LanguageConfig, UkReplacement } from '@bindery/core';
+import { rewriteImageLinks, makePortableMarkdown, legacyImageName, hasImageLink } from './images.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,8 @@ export interface MergeOptions {
     author?: string;
     /** Book title override */
     bookTitle?: string;
+    /** Book-level fallback cover image (relative to root), used when `language.coverImage` is unset. */
+    coverImage?: string;
     /** Output directory (relative to root) */
     outputDir: string;
     /** Merged file prefix */
@@ -60,13 +63,13 @@ interface ActInfo {
     subtitle?: string;
 }
 
-type FileType =
+export type FileType =
     | { kind: 'prologue' }
     | { kind: 'act'; act: ActInfo }
     | { kind: 'chapter'; act: ActInfo; num: number }
     | { kind: 'epilogue' };
 
-interface OrderedFile {
+export interface OrderedFile {
     filePath: string;
     fileType: FileType;
 }
@@ -79,7 +82,6 @@ const H1_RE = /^\s*#\s+(.+?)\s*$/m;
 const SLUG_CLEAN_RE = /[^\p{L}\p{N}\s-]/gu;
 const BLANK_LINES_RE = /\n{2,}/g;
 const FIRST_H1_RE = /^(\s*)#\s+/m;
-const HEADING_LINE_RE = /^#[^\n]*\n/m;
 const FENCE_RE = /^\s*```/;
 
 // ─── UK Conversion (US → UK) ───────────────────────────────────────────────
@@ -340,7 +342,7 @@ function formatActTitle(act: ActInfo, lang: LanguageConfig): string {
 
 // ─── File Discovery ─────────────────────────────────────────────────────────
 
-function getOrderedFiles(langPath: string, lang: LanguageConfig): OrderedFile[] {
+export function getOrderedFiles(langPath: string, lang: LanguageConfig): OrderedFile[] {
     const files: OrderedFile[] = [];
 
     // Prologue
@@ -454,7 +456,7 @@ const PAGE_BREAK = `
 \`\`\`
 `;
 
-function buildMarkdownContent(files: OrderedFile[], options: MergeOptions): string {
+function buildMarkdownContent(files: OrderedFile[], options: MergeOptions, resolver: ImageResolver): string {
     let content = '';
 
     if (options.includeToc) {
@@ -468,8 +470,7 @@ function buildMarkdownContent(files: OrderedFile[], options: MergeOptions): stri
         switch (file.fileType.kind) {
             case 'prologue':
             case 'epilogue': {
-                const fileContent = fs.readFileSync(file.filePath, 'utf-8');
-                content += fileContent;
+                content += resolver.read(file);
                 break;
             }
             case 'act':
@@ -477,12 +478,11 @@ function buildMarkdownContent(files: OrderedFile[], options: MergeOptions): stri
                 content += `# ${formatActTitle(file.fileType.act, options.language)}\n\n`;
                 break;
             case 'chapter': {
-                const fileContent = fs.readFileSync(file.filePath, 'utf-8');
                 if (currentAct !== file.fileType.act.number) {
                     currentAct = file.fileType.act.number;
                     content += `# ${formatActTitle(file.fileType.act, options.language)}\n\n`;
                 }
-                content += fileContent;
+                content += resolver.read(file);
                 break;
             }
         }
@@ -506,36 +506,111 @@ function hasNextContentFile(files: OrderedFile[], currentIndex: number): boolean
     return false;
 }
 
-function imageMarkdownFor(file: OrderedFile, options: MergeOptions): string | undefined {
-    let imageName: string;
-    switch (file.fileType.kind) {
-        case 'prologue': imageName = 'prologue.jpg'; break;
-        case 'epilogue': imageName = 'epilogue.jpg'; break;
-        case 'chapter': imageName = `chapter${file.fileType.num}.jpg`; break;
-        default: return undefined;
-    }
-
-    const imagePath = path.join(options.root, 'images', imageName);
-    if (!fs.existsSync(imagePath)) { return undefined; }
-    return `![](${imagePath.replaceAll(/\\/g, '/')})\n\n`;
+/**
+ * Reads chapter content with markdown image links resolved to absolute paths.
+ * Caches per file so multiple output types report each warning only once.
+ */
+interface ImageResolver {
+    read(file: OrderedFile): string;
+    warnings: string[];
 }
 
-function insertImageAfterHeading(content: string, imageMd: string): string {
-    const m = HEADING_LINE_RE.exec(content);
-    if (m) {
-        const end = m.index + m[0].length;
-        return content.substring(0, end) + imageMd + content.substring(end);
-    }
-    return imageMd + content;
+function createImageResolver(): ImageResolver {
+    const cache = new Map<string, string>();
+    const warnings: string[] = [];
+    return {
+        warnings,
+        read(file: OrderedFile): string {
+            const cached = cache.get(file.filePath);
+            if (cached !== undefined) { return cached; }
+            const raw = fs.readFileSync(file.filePath, 'utf-8');
+            const result = rewriteImageLinks(raw, path.dirname(file.filePath), path.basename(file.filePath));
+            warnings.push(...result.warnings);
+            cache.set(file.filePath, result.content);
+            return result.content;
+        },
+    };
 }
 
-function coverMarkdown(options: MergeOptions): string | undefined {
-    const coverPath = path.join(options.root, options.storyFolder, options.language.folderName, 'cover.jpg');
-    if (!fs.existsSync(coverPath)) { return undefined; }
+/**
+ * Legacy implicit chapter images (images/chapterN.jpg) are no longer injected
+ * automatically. Warn when such an image exists but its file has no inline link,
+ * so users who relied on the old behavior are told at export time.
+ */
+function detectOrphanedLegacyImages(files: OrderedFile[], options: MergeOptions, resolver: ImageResolver): string[] {
+    const warnings: string[] = [];
+    for (const file of files) {
+        const kind = file.fileType.kind;
+        if (kind === 'act') { continue; }
+        const name = legacyImageName(kind, kind === 'chapter' ? file.fileType.num : undefined);
+        const imagePath = path.join(options.root, 'images', name);
+        if (!fs.existsSync(imagePath)) { continue; }
+        if (!hasImageLink(resolver.read(file))) {
+            warnings.push(
+                `images/${name} exists but ${path.basename(file.filePath)} has no image link. ` +
+                'Implicit chapter images are no longer inserted — add ![](path/to/image) to the chapter, ' +
+                'or run the image link migration in VS Code/Obsidian.'
+            );
+        }
+    }
+    return warnings;
+}
+
+export interface CoverResolution {
+    coverPath?: string;
+    warning?: string;
+}
+
+/**
+ * Resolve the cover image for a language, in priority order:
+ *
+ * 1. `language.coverImage` — per-language cover (e.g. translated cover text/art).
+ * 2. `options.coverImage` — book-level fallback, for a single cover design shared
+ *    across every translation.
+ * 3. Legacy `<storyFolder>/<langFolder>/cover.jpg` convention, with a warning
+ *    nudging the user to set one of the above (suggested: `images/<code>-cover.jpg`).
+ *
+ * All paths are relative to the book root.
+ */
+export function resolveCoverImage(options: MergeOptions): CoverResolution {
+    const languageConfigured = options.language.coverImage?.trim();
+    const bookConfigured = options.coverImage?.trim();
+    const configured = languageConfigured || bookConfigured;
+
+    if (configured) {
+        const resolved = path.join(options.root, configured);
+        if (fs.existsSync(resolved)) {
+            return { coverPath: resolved };
+        }
+        const scope = languageConfigured ? `language ${options.language.code}` : 'book-level';
+        return { warning: `Configured ${scope} coverImage not found: ${configured}` };
+    }
+
+    const legacy = path.join(options.root, options.storyFolder, options.language.folderName, 'cover.jpg');
+    if (fs.existsSync(legacy)) {
+        return {
+            coverPath: legacy,
+            warning:
+                `Using legacy cover image at ${options.storyFolder}/${options.language.folderName}/cover.jpg — ` +
+                `set languages[].coverImage or a book-level coverImage in settings.json (suggested: images/${options.language.code}-cover.jpg) to make this explicit.`,
+        };
+    }
+
+    return {};
+}
+
+function coverMarkdownFor(coverPath: string | undefined): string | undefined {
+    if (!coverPath) { return undefined; }
     return `![](${coverPath.replaceAll(/\\/g, '/')})\n\n`;
 }
 
-function buildPandocContent(files: OrderedFile[], options: MergeOptions, outputType: OutputType): string {
+function buildPandocContent(
+    files: OrderedFile[],
+    options: MergeOptions,
+    outputType: OutputType,
+    resolver: ImageResolver,
+    coverPath: string | undefined
+): string {
     let content = '';
 
     const pageBreak = outputType === 'pdf'
@@ -543,7 +618,7 @@ function buildPandocContent(files: OrderedFile[], options: MergeOptions, outputT
         : PAGE_BREAK;
 
     if (outputType === 'docx' || outputType === 'pdf') {
-        const cover = coverMarkdown(options);
+        const cover = coverMarkdownFor(coverPath);
         if (cover) {
             content += cover + pageBreak + '\n';
         }
@@ -555,21 +630,14 @@ function buildPandocContent(files: OrderedFile[], options: MergeOptions, outputT
         switch (file.fileType.kind) {
             case 'prologue':
             case 'epilogue': {
-                let fileContent = fs.readFileSync(file.filePath, 'utf-8');
-                const img = imageMarkdownFor(file, options);
-                if (img) { fileContent = insertImageAfterHeading(fileContent, img); }
-                content += fileContent;
+                content += resolver.read(file);
                 break;
             }
             case 'act':
                 content += `# ${formatActTitle(file.fileType.act, options.language)}\n\n`;
                 break;
             case 'chapter': {
-                let fileContent = fs.readFileSync(file.filePath, 'utf-8');
-                fileContent = demoteH1ToH2(fileContent);
-                const img = imageMarkdownFor(file, options);
-                if (img) { fileContent = insertImageAfterHeading(fileContent, img); }
-                content += fileContent;
+                content += demoteH1ToH2(resolver.read(file));
                 break;
             }
         }
@@ -636,7 +704,8 @@ function runPandoc(
     title: string,
     lang: LanguageConfig,
     author: string | undefined,
-    pandocPath: string
+    pandocPath: string,
+    coverPath?: string
 ): Promise<void> {
     const args: string[] = [
         inputPath,
@@ -664,9 +733,8 @@ function runPandoc(
 
     if (outputType === 'epub') {
         args.push('--split-level=2');
-        const cover = path.join(root, 'Story', lang.folderName, 'cover.jpg');
-        if (fs.existsSync(cover)) {
-            args.push('--epub-cover-image', cover);
+        if (coverPath && fs.existsSync(coverPath)) {
+            args.push('--epub-cover-image', coverPath);
         }
     }
 
@@ -802,22 +870,29 @@ export async function mergeBook(options: MergeOptions): Promise<MergeResult> {
         }
 
         const title = resolveBookTitle(options);
+        const resolver = createImageResolver();
+        warnings.push(...detectOrphanedLegacyImages(files, options, resolver));
+
+        const coverResolution = resolveCoverImage(options);
+        if (coverResolution.warning) { warnings.push(coverResolution.warning); }
 
         for (const outputType of options.outputTypes) {
             const outputPath = path.join(outputDir, `${baseName}.${outputType}`);
 
             if (outputType === 'md') {
-                const content = buildMarkdownContent(files, options);
-                fs.writeFileSync(outputPath, content, 'utf-8');
+                const content = buildMarkdownContent(files, options, resolver);
+                const portable = makePortableMarkdown(content, outputDir);
+                warnings.push(...portable.warnings);
+                fs.writeFileSync(outputPath, portable.content, 'utf-8');
                 outputs.push(outputPath);
             } else if (outputType === 'pdf') {
                 const libreOfficePath = options.libreOfficePath?.trim() || 'libreoffice';
                 const tempMdPath = path.join(outputDir, `${baseName}_pdf_temp.md`);
                 const tempDocxPath = path.join(outputDir, `${baseName}_pdf_temp.docx`);
-                const content = buildPandocContent(files, options, 'docx');
+                const content = buildPandocContent(files, options, 'docx', resolver, coverResolution.coverPath);
                 fs.writeFileSync(tempMdPath, content, 'utf-8');
                 try {
-                    await runPandoc(tempMdPath, tempDocxPath, 'docx', options.root, title, options.language, options.author, options.pandocPath);
+                    await runPandoc(tempMdPath, tempDocxPath, 'docx', options.root, title, options.language, options.author, options.pandocPath, coverResolution.coverPath);
                     await runLibreOfficeToPdf(tempDocxPath, outputDir, outputPath, libreOfficePath);
                     outputs.push(outputPath);
                 } finally {
@@ -825,11 +900,11 @@ export async function mergeBook(options: MergeOptions): Promise<MergeResult> {
                     try { fs.unlinkSync(tempDocxPath); } catch { /* ignore */ }
                 }
             } else {
-                const content = buildPandocContent(files, options, outputType);
+                const content = buildPandocContent(files, options, outputType, resolver, coverResolution.coverPath);
                 const tempPath = path.join(outputDir, `${baseName}_temp.md`);
                 fs.writeFileSync(tempPath, content, 'utf-8');
                 try {
-                    await runPandoc(tempPath, outputPath, outputType, options.root, title, options.language, options.author, options.pandocPath);
+                    await runPandoc(tempPath, outputPath, outputType, options.root, title, options.language, options.author, options.pandocPath, coverResolution.coverPath);
                     outputs.push(outputPath);
                 } finally {
                     try { fs.unlinkSync(tempPath); } catch { /* ignore */ }
@@ -837,6 +912,7 @@ export async function mergeBook(options: MergeOptions): Promise<MergeResult> {
             }
         }
 
+        warnings.push(...resolver.warnings);
         return { outputs, filesMerged: files.length, warnings };
     } finally {
         if (isLegacyUk) {

--- a/bindery-merge/src/merge.ts
+++ b/bindery-merge/src/merge.ts
@@ -546,8 +546,9 @@ function detectOrphanedLegacyImages(files: OrderedFile[], options: MergeOptions,
         const imagePath = path.join(options.root, 'images', name);
         if (!fs.existsSync(imagePath)) { continue; }
         if (!hasImageLink(resolver.read(file))) {
+            const relativePath = path.relative(options.root, file.filePath).replaceAll('\\', '/');
             warnings.push(
-                `images/${name} exists but ${path.basename(file.filePath)} has no image link. ` +
+                `images/${name} exists but ${relativePath} has no image link. ` +
                 'Implicit chapter images are no longer inserted — add ![](path/to/image) to the chapter, ' +
                 'or run the image link migration in VS Code/Obsidian.'
             );

--- a/bindery-merge/test/cover.test.ts
+++ b/bindery-merge/test/cover.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for resolveCoverImage() — explicit settings-based cover
+ * resolution with a legacy-convention fallback.
+ */
+
+import * as fs   from 'node:fs';
+import * as os   from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveCoverImage, type MergeOptions } from '../src/merge';
+import type { LanguageConfig } from '@bindery/core';
+
+const tempRoots: string[] = [];
+
+function makeRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bindery-cover-test-'));
+    tempRoots.push(root);
+    return root;
+}
+
+function write(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+afterEach(() => {
+    for (const root of tempRoots.splice(0, tempRoots.length)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+const EN: LanguageConfig = {
+    code:          'EN',
+    folderName:    'EN',
+    chapterWord:   'Chapter',
+    actPrefix:     'Act',
+    prologueLabel: 'Prologue',
+    epilogueLabel: 'Epilogue',
+};
+
+function makeOptions(root: string, language: LanguageConfig, bookCoverImage?: string): MergeOptions {
+    return {
+        root,
+        storyFolder:      'Story',
+        language,
+        outputTypes:      ['md'],
+        includeToc:       false,
+        includeSeparators: false,
+        outputDir:        'Merged',
+        filePrefix:       'Book',
+        pandocPath:       'pandoc',
+        coverImage:       bookCoverImage,
+    };
+}
+
+describe('resolveCoverImage()', () => {
+    it('uses the explicit coverImage setting when the file exists', () => {
+        const root = makeRoot();
+        write(path.join(root, 'images', 'EN-cover.jpg'), 'jpg');
+        const lang: LanguageConfig = { ...EN, coverImage: 'images/EN-cover.jpg' };
+
+        const result = resolveCoverImage(makeOptions(root, lang));
+
+        expect(result.coverPath).toBe(path.join(root, 'images', 'EN-cover.jpg'));
+        expect(result.warning).toBeUndefined();
+    });
+
+    it('warns without a coverPath when the configured file is missing', () => {
+        const root = makeRoot();
+        const lang: LanguageConfig = { ...EN, coverImage: 'images/EN-cover.jpg' };
+
+        const result = resolveCoverImage(makeOptions(root, lang));
+
+        expect(result.coverPath).toBeUndefined();
+        expect(result.warning).toContain('EN');
+        expect(result.warning).toContain('images/EN-cover.jpg');
+    });
+
+    it('falls back to the legacy Story/<lang>/cover.jpg convention with a warning', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'jpg');
+
+        const result = resolveCoverImage(makeOptions(root, EN));
+
+        expect(result.coverPath).toBe(path.join(root, 'Story', 'EN', 'cover.jpg'));
+        expect(result.warning).toContain('legacy');
+        expect(result.warning).toContain('coverImage');
+        expect(result.warning).toContain('images/EN-cover.jpg');
+    });
+
+    it('prefers the explicit setting over a legacy file that also exists', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'legacy');
+        write(path.join(root, 'images', 'EN-cover.jpg'), 'explicit');
+        const lang: LanguageConfig = { ...EN, coverImage: 'images/EN-cover.jpg' };
+
+        const result = resolveCoverImage(makeOptions(root, lang));
+
+        expect(result.coverPath).toBe(path.join(root, 'images', 'EN-cover.jpg'));
+        expect(result.warning).toBeUndefined();
+    });
+
+    it('returns neither coverPath nor warning when no cover exists anywhere', () => {
+        const root = makeRoot();
+
+        const result = resolveCoverImage(makeOptions(root, EN));
+
+        expect(result.coverPath).toBeUndefined();
+        expect(result.warning).toBeUndefined();
+    });
+
+    // ─── Book-level fallback ──────────────────────────────────────────────────
+
+    it('falls back to the book-level coverImage when the language has none', () => {
+        const root = makeRoot();
+        write(path.join(root, 'images', 'cover.jpg'), 'book-cover');
+
+        const result = resolveCoverImage(makeOptions(root, EN, 'images/cover.jpg'));
+
+        expect(result.coverPath).toBe(path.join(root, 'images', 'cover.jpg'));
+        expect(result.warning).toBeUndefined();
+    });
+
+    it('prefers a per-language coverImage over the book-level fallback', () => {
+        const root = makeRoot();
+        write(path.join(root, 'images', 'cover.jpg'), 'book-cover');
+        write(path.join(root, 'images', 'EN-cover.jpg'), 'lang-cover');
+        const lang: LanguageConfig = { ...EN, coverImage: 'images/EN-cover.jpg' };
+
+        const result = resolveCoverImage(makeOptions(root, lang, 'images/cover.jpg'));
+
+        expect(result.coverPath).toBe(path.join(root, 'images', 'EN-cover.jpg'));
+    });
+
+    it('warns without a coverPath when the book-level file is missing', () => {
+        const root = makeRoot();
+
+        const result = resolveCoverImage(makeOptions(root, EN, 'images/cover.jpg'));
+
+        expect(result.coverPath).toBeUndefined();
+        expect(result.warning).toContain('book-level');
+        expect(result.warning).toContain('images/cover.jpg');
+    });
+
+    it('does not fall through to the legacy convention when the book-level setting is configured but missing', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'legacy');
+
+        const result = resolveCoverImage(makeOptions(root, EN, 'images/cover.jpg'));
+
+        // A configured-but-missing setting is a warning, not silently replaced by the legacy fallback.
+        expect(result.coverPath).toBeUndefined();
+        expect(result.warning).toContain('book-level');
+    });
+});

--- a/bindery-merge/test/images.test.ts
+++ b/bindery-merge/test/images.test.ts
@@ -104,6 +104,14 @@ describe('rewriteImageLinks()', () => {
         expect(result.content).toContain(abs.replaceAll('\\', '/'));
         expect(result.warnings).toEqual([]);
     });
+
+    it('does not hang on pathological repeated image/embed openers', () => {
+        const root = makeRoot();
+        const start = Date.now();
+        rewriteImageLinks('![['.repeat(20000), root, 'ch5.md');
+        rewriteImageLinks('![](!'.repeat(20000), root, 'ch5.md');
+        expect(Date.now() - start).toBeLessThan(2000);
+    });
 });
 
 // ─── makePortableMarkdown ─────────────────────────────────────────────────────

--- a/bindery-merge/test/images.test.ts
+++ b/bindery-merge/test/images.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for images.ts — inline image link rewriting, wikilink stripping,
+ * portable markdown export, and legacy image helpers.
+ */
+
+import * as fs   from 'node:fs';
+import * as os   from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    rewriteImageLinks,
+    makePortableMarkdown,
+    legacyImageName,
+    hasImageLink,
+} from '../src/images';
+
+const tempRoots: string[] = [];
+
+function makeRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bindery-images-test-'));
+    tempRoots.push(root);
+    return root;
+}
+
+function write(filePath: string, content: string | Buffer): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+}
+
+afterEach(() => {
+    for (const root of tempRoots.splice(0, tempRoots.length)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+// ─── rewriteImageLinks ────────────────────────────────────────────────────────
+
+describe('rewriteImageLinks()', () => {
+    it('resolves a relative link against the source directory', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Images', 'map.png'), 'fake-png');
+        const chapterDir = path.join(root, 'Story', 'EN');
+        fs.mkdirSync(chapterDir, { recursive: true });
+
+        const result = rewriteImageLinks('# Ch1\n\n![A map](../../Images/map.png)\n', chapterDir, 'ch1.md');
+
+        const expected = path.join(root, 'Images', 'map.png').replaceAll('\\', '/');
+        expect(result.content).toContain(`![A map](${expected})`);
+        expect(result.warnings).toEqual([]);
+        expect(result.imagePaths).toEqual([expected]);
+    });
+
+    it('keeps a title suffix intact', () => {
+        const root = makeRoot();
+        write(path.join(root, 'map.png'), 'fake');
+
+        const result = rewriteImageLinks('![alt](map.png "The Map")', root, 'ch1.md');
+
+        const expected = path.join(root, 'map.png').replaceAll('\\', '/');
+        expect(result.content).toBe(`![alt](${expected} "The Map")`);
+    });
+
+    it('leaves external URLs untouched', () => {
+        const content = '![remote](https://example.com/pic.png) ![data](data:image/png;base64,AAA=)';
+        const result = rewriteImageLinks(content, makeRoot(), 'ch1.md');
+        expect(result.content).toBe(content);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('warns on a missing image but keeps the link visible', () => {
+        const root = makeRoot();
+        const result = rewriteImageLinks('![](nope/gone.png)', root, 'ch7.md');
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings[0]).toContain('ch7.md');
+        expect(result.warnings[0]).toContain('gone.png');
+        expect(result.content).toContain('gone.png');
+        expect(result.imagePaths).toEqual([]);
+    });
+
+    it('strips Obsidian wikilink embeds with a warning', () => {
+        const result = rewriteImageLinks('Before\n![[vault-pic.png]]\nAfter', makeRoot(), 'ch2.md');
+        expect(result.content).not.toContain('![[');
+        expect(result.content).toContain('Before');
+        expect(result.content).toContain('After');
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings[0]).toContain('ch2.md');
+        expect(result.warnings[0]).toContain('vault-pic.png');
+    });
+
+    it('does not touch links inside fenced code blocks', () => {
+        const content = '```\n![in-fence](x.png)\n![[wiki]]\n```\n';
+        const result = rewriteImageLinks(content, makeRoot(), 'ch3.md');
+        expect(result.content).toBe(content);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('normalizes an already-absolute path without relocating it', () => {
+        const root = makeRoot();
+        write(path.join(root, 'pic.png'), 'fake');
+        const abs = path.join(root, 'pic.png');
+
+        const result = rewriteImageLinks(`![](${abs.replaceAll('\\', '/')})`, path.join(root, 'elsewhere'), 'ch4.md');
+
+        expect(result.content).toContain(abs.replaceAll('\\', '/'));
+        expect(result.warnings).toEqual([]);
+    });
+});
+
+// ─── makePortableMarkdown ─────────────────────────────────────────────────────
+
+describe('makePortableMarkdown()', () => {
+    it('copies absolute-path images to Images/ and rewrites links relative', () => {
+        const root = makeRoot();
+        const src = path.join(root, 'assets', 'map.png');
+        write(src, 'png-bytes');
+        const outputDir = path.join(root, 'Merged');
+        fs.mkdirSync(outputDir, { recursive: true });
+
+        const content = `![A map](${src.replaceAll('\\', '/')})`;
+        const result = makePortableMarkdown(content, outputDir);
+
+        expect(result.content).toBe('![A map](Images/map.png)');
+        expect(fs.readFileSync(path.join(outputDir, 'Images', 'map.png'), 'utf-8')).toBe('png-bytes');
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('dedupes name collisions with numeric suffixes and reuses the same dest for the same source', () => {
+        const root = makeRoot();
+        const srcA = path.join(root, 'a', 'map.png');
+        const srcB = path.join(root, 'b', 'map.png');
+        write(srcA, 'aaa');
+        write(srcB, 'bbb');
+        const outputDir = path.join(root, 'Merged');
+        fs.mkdirSync(outputDir, { recursive: true });
+
+        const fa = srcA.replaceAll('\\', '/');
+        const fb = srcB.replaceAll('\\', '/');
+        const result = makePortableMarkdown(`![](${fa})\n![](${fb})\n![](${fa})`, outputDir);
+
+        expect(result.content).toBe('![](Images/map.png)\n![](Images/map-2.png)\n![](Images/map.png)');
+        expect(fs.readFileSync(path.join(outputDir, 'Images', 'map.png'), 'utf-8')).toBe('aaa');
+        expect(fs.readFileSync(path.join(outputDir, 'Images', 'map-2.png'), 'utf-8')).toBe('bbb');
+        expect(result.copied).toHaveLength(2);
+    });
+
+    it('leaves external URLs and missing files untouched', () => {
+        const root = makeRoot();
+        const outputDir = path.join(root, 'Merged');
+        fs.mkdirSync(outputDir, { recursive: true });
+        const missing = path.join(root, 'ghost.png').replaceAll('\\', '/');
+
+        const content = `![](https://example.com/x.png)\n![](${missing})`;
+        const result = makePortableMarkdown(content, outputDir);
+
+        expect(result.content).toBe(content);
+        expect(result.copied).toEqual([]);
+        expect(fs.existsSync(path.join(outputDir, 'Images'))).toBe(false);
+    });
+});
+
+// ─── legacy helpers ───────────────────────────────────────────────────────────
+
+describe('legacyImageName() / hasImageLink()', () => {
+    it('maps kinds to legacy image names', () => {
+        expect(legacyImageName('prologue')).toBe('prologue.jpg');
+        expect(legacyImageName('epilogue')).toBe('epilogue.jpg');
+        expect(legacyImageName('chapter', 12)).toBe('chapter12.jpg');
+    });
+
+    it('detects image links regardless of prior regex state', () => {
+        // Called twice to guard against lastIndex leakage on the shared regex.
+        expect(hasImageLink('text ![x](a.png) more')).toBe(true);
+        expect(hasImageLink('text ![x](a.png) more')).toBe(true);
+        expect(hasImageLink('no images here, just [a link](x.md)')).toBe(false);
+    });
+});

--- a/bindery-merge/test/legacy-images.test.ts
+++ b/bindery-merge/test/legacy-images.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for legacy-images.ts — migration from implicit chapterN.jpg
+ * images to explicit inline markdown links.
+ */
+
+import * as fs   from 'node:fs';
+import * as os   from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+    proposeLegacyImageMigration, applyLegacyImageMigration,
+    proposeLegacyCoverMigration, applyLegacyCoverMigration,
+} from '../src/legacy-images';
+import type { LanguageConfig } from '@bindery/core';
+
+const tempRoots: string[] = [];
+
+function makeRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bindery-legacy-test-'));
+    tempRoots.push(root);
+    return root;
+}
+
+function write(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+afterEach(() => {
+    for (const root of tempRoots.splice(0, tempRoots.length)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+const EN: LanguageConfig = {
+    code:          'EN',
+    folderName:    'EN',
+    chapterWord:   'Chapter',
+    actPrefix:     'Act',
+    prologueLabel: 'Prologue',
+    epilogueLabel: 'Epilogue',
+};
+
+function scaffold(root: string): { ch1: string; prologue: string } {
+    const prologue = path.join(root, 'Story', 'EN', 'Prologue.md');
+    const ch1 = path.join(root, 'Story', 'EN', 'Act I', 'Chapter 1.md');
+    write(prologue, '# Prologue\n\nOnce upon a time.\n');
+    write(ch1, '# The Beginning\n\nIt began.\n');
+    return { ch1, prologue };
+}
+
+describe('proposeLegacyImageMigration()', () => {
+    it('proposes links for legacy images that are not referenced', () => {
+        const root = makeRoot();
+        const { ch1 } = scaffold(root);
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+        write(path.join(root, 'images', 'prologue.jpg'), 'jpg');
+
+        const proposals = proposeLegacyImageMigration(root, 'Story', EN);
+
+        expect(proposals).toHaveLength(2);
+        const ch1Proposal = proposals.find(p => p.filePath === ch1);
+        expect(ch1Proposal).toBeDefined();
+        expect(ch1Proposal!.relativeLink).toBe('../../../images/chapter1.jpg');
+        const prologueProposal = proposals.find(p => p.filePath !== ch1);
+        expect(prologueProposal!.relativeLink).toBe('../../images/prologue.jpg');
+    });
+
+    it('skips files that already contain an image link', () => {
+        const root = makeRoot();
+        const { ch1 } = scaffold(root);
+        write(ch1, '# The Beginning\n\n![](../../../images/chapter1.jpg)\n\nIt began.\n');
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+
+        expect(proposeLegacyImageMigration(root, 'Story', EN)).toEqual([]);
+    });
+
+    it('returns empty for a missing language folder or missing images', () => {
+        const root = makeRoot();
+        expect(proposeLegacyImageMigration(root, 'Story', EN)).toEqual([]);
+        scaffold(root);
+        expect(proposeLegacyImageMigration(root, 'Story', EN)).toEqual([]);
+    });
+});
+
+describe('applyLegacyImageMigration()', () => {
+    it('inserts the link after the first heading', () => {
+        const root = makeRoot();
+        const { ch1 } = scaffold(root);
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+
+        const proposals = proposeLegacyImageMigration(root, 'Story', EN);
+        const changed = applyLegacyImageMigration(proposals);
+
+        expect(changed).toBe(1);
+        const content = fs.readFileSync(ch1, 'utf-8');
+        expect(content).toBe('# The Beginning\n\n![](../../../images/chapter1.jpg)\n\nIt began.\n');
+    });
+
+    it('prepends when the file has no heading', () => {
+        const root = makeRoot();
+        const ch1 = path.join(root, 'Story', 'EN', 'Act I', 'Chapter 1.md');
+        write(ch1, 'No heading here.\n');
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+
+        const proposals = proposeLegacyImageMigration(root, 'Story', EN);
+        applyLegacyImageMigration(proposals);
+
+        expect(fs.readFileSync(ch1, 'utf-8')).toBe('![](../../../images/chapter1.jpg)\n\nNo heading here.\n');
+    });
+
+    it('skips files that gained an image link between scan and apply', () => {
+        const root = makeRoot();
+        const { ch1 } = scaffold(root);
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+
+        const proposals = proposeLegacyImageMigration(root, 'Story', EN);
+        write(ch1, '# The Beginning\n\n![](other.png)\n');
+
+        expect(applyLegacyImageMigration(proposals)).toBe(0);
+        expect(fs.readFileSync(ch1, 'utf-8')).toContain('other.png');
+    });
+});
+
+describe('proposeLegacyCoverMigration()', () => {
+    it('proposes moving a legacy cover.jpg into images/<code>-cover.jpg', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'jpg');
+
+        const proposals = proposeLegacyCoverMigration(root, 'Story', [EN]);
+
+        expect(proposals).toEqual([{
+            languageCode: 'EN',
+            oldPath: path.join(root, 'Story', 'EN', 'cover.jpg'),
+            newRelativePath: 'images/EN-cover.jpg',
+        }]);
+    });
+
+    it('skips a language that already has coverImage set', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'jpg');
+        const lang: LanguageConfig = { ...EN, coverImage: 'images/EN-cover.jpg' };
+
+        expect(proposeLegacyCoverMigration(root, 'Story', [lang])).toEqual([]);
+    });
+
+    it('skips a language with no legacy cover.jpg on disk', () => {
+        const root = makeRoot();
+        expect(proposeLegacyCoverMigration(root, 'Story', [EN])).toEqual([]);
+    });
+
+    it('handles multiple languages independently', () => {
+        const root = makeRoot();
+        const NL: LanguageConfig = { ...EN, code: 'NL', folderName: 'NL' };
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'jpg');
+        write(path.join(root, 'Story', 'NL', 'cover.jpg'), 'jpg');
+
+        const proposals = proposeLegacyCoverMigration(root, 'Story', [EN, NL]);
+
+        expect(proposals).toHaveLength(2);
+        expect(proposals.map(p => p.languageCode).sort()).toEqual(['EN', 'NL']);
+    });
+});
+
+describe('applyLegacyCoverMigration()', () => {
+    it('moves the file and reports the new relative path', () => {
+        const root = makeRoot();
+        const oldPath = path.join(root, 'Story', 'EN', 'cover.jpg');
+        write(oldPath, 'jpg-bytes');
+
+        const proposals = proposeLegacyCoverMigration(root, 'Story', [EN]);
+        const applied = applyLegacyCoverMigration(root, proposals);
+
+        expect(applied.get('EN')).toBe('images/EN-cover.jpg');
+        expect(fs.existsSync(oldPath)).toBe(false);
+        expect(fs.readFileSync(path.join(root, 'images', 'EN-cover.jpg'), 'utf-8')).toBe('jpg-bytes');
+    });
+
+    it('does not overwrite an existing destination file', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'new-content');
+        write(path.join(root, 'images', 'EN-cover.jpg'), 'existing-content');
+
+        const proposals = proposeLegacyCoverMigration(root, 'Story', [EN]);
+        const applied = applyLegacyCoverMigration(root, proposals);
+
+        expect(applied.size).toBe(0);
+        expect(fs.readFileSync(path.join(root, 'images', 'EN-cover.jpg'), 'utf-8')).toBe('existing-content');
+        // Source is left in place since the move was skipped.
+        expect(fs.existsSync(path.join(root, 'Story', 'EN', 'cover.jpg'))).toBe(true);
+    });
+
+    it('skips a proposal whose source file no longer exists', () => {
+        const root = makeRoot();
+        write(path.join(root, 'Story', 'EN', 'cover.jpg'), 'jpg');
+        const proposals = proposeLegacyCoverMigration(root, 'Story', [EN]);
+        fs.unlinkSync(path.join(root, 'Story', 'EN', 'cover.jpg'));
+
+        const applied = applyLegacyCoverMigration(root, proposals);
+
+        expect(applied.size).toBe(0);
+    });
+});

--- a/bindery-merge/test/merge-images.test.ts
+++ b/bindery-merge/test/merge-images.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests: inline images through the full mergeBook() 'md' flow.
+ * Does NOT invoke pandoc.
+ */
+
+import * as fs   from 'node:fs';
+import * as os   from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mergeBook, type MergeOptions } from '../src/merge';
+import type { LanguageConfig } from '@bindery/core';
+
+const tempRoots: string[] = [];
+
+function makeRoot(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bindery-merge-img-test-'));
+    tempRoots.push(root);
+    return root;
+}
+
+function write(filePath: string, content: string): void {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, 'utf-8');
+}
+
+afterEach(() => {
+    for (const root of tempRoots.splice(0, tempRoots.length)) {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
+});
+
+const EN: LanguageConfig = {
+    code:          'EN',
+    folderName:    'EN',
+    chapterWord:   'Chapter',
+    actPrefix:     'Act',
+    prologueLabel: 'Prologue',
+    epilogueLabel: 'Epilogue',
+};
+
+function makeOptions(root: string, overrides: Partial<MergeOptions> = {}): MergeOptions {
+    return {
+        root,
+        storyFolder:      'Story',
+        language:         EN,
+        outputTypes:      ['md'],
+        includeToc:       false,
+        includeSeparators: false,
+        outputDir:        'Merged',
+        filePrefix:       'Book',
+        pandocPath:       'pandoc',
+        ...overrides,
+    };
+}
+
+describe('mergeBook() with inline images (md output)', () => {
+    it('copies referenced images to Merged/Images and rewrites links relative', async () => {
+        const root = makeRoot();
+        write(path.join(root, 'Images', 'map.png'), 'png-bytes');
+        write(
+            path.join(root, 'Story', 'EN', 'Act I', 'Chapter 1.md'),
+            '# Ch1\n\nSee the map:\n\n![World map](../../../Images/map.png)\n'
+        );
+
+        const result = await mergeBook(makeOptions(root));
+
+        const merged = fs.readFileSync(result.outputs[0], 'utf-8');
+        expect(merged).toContain('![World map](Images/map.png)');
+        expect(fs.readFileSync(path.join(root, 'Merged', 'Images', 'map.png'), 'utf-8')).toBe('png-bytes');
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('reports missing images and stripped wikilinks as warnings, once per file', async () => {
+        const root = makeRoot();
+        write(
+            path.join(root, 'Story', 'EN', 'Act I', 'Chapter 1.md'),
+            '# Ch1\n\n![](../missing.png)\n\n![[obsidian-embed.png]]\n'
+        );
+
+        const result = await mergeBook(makeOptions(root));
+
+        expect(result.warnings.filter(w => w.includes('missing.png'))).toHaveLength(1);
+        expect(result.warnings.filter(w => w.includes('obsidian-embed.png'))).toHaveLength(1);
+        const merged = fs.readFileSync(result.outputs[0], 'utf-8');
+        expect(merged).not.toContain('![[');
+    });
+
+    it('warns about orphaned legacy chapter images instead of injecting them', async () => {
+        const root = makeRoot();
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+        write(path.join(root, 'Story', 'EN', 'Act I', 'Chapter 1.md'), '# Ch1\n\nText.\n');
+
+        const result = await mergeBook(makeOptions(root));
+
+        const merged = fs.readFileSync(result.outputs[0], 'utf-8');
+        expect(merged).not.toContain('chapter1.jpg');
+        expect(result.warnings.some(w => w.includes('images/chapter1.jpg') && w.includes('no image link'))).toBe(true);
+    });
+
+    it('does not warn when the chapter references the legacy image explicitly', async () => {
+        const root = makeRoot();
+        write(path.join(root, 'images', 'chapter1.jpg'), 'jpg');
+        write(
+            path.join(root, 'Story', 'EN', 'Act I', 'Chapter 1.md'),
+            '# Ch1\n\n![](../../../images/chapter1.jpg)\n\nText.\n'
+        );
+
+        const result = await mergeBook(makeOptions(root));
+
+        expect(result.warnings).toEqual([]);
+        const merged = fs.readFileSync(result.outputs[0], 'utf-8');
+        expect(merged).toContain('![](Images/chapter1.jpg)');
+    });
+});

--- a/bindery-merge/test/merge-images.test.ts
+++ b/bindery-merge/test/merge-images.test.ts
@@ -95,6 +95,7 @@ describe('mergeBook() with inline images (md output)', () => {
         const merged = fs.readFileSync(result.outputs[0], 'utf-8');
         expect(merged).not.toContain('chapter1.jpg');
         expect(result.warnings.some(w => w.includes('images/chapter1.jpg') && w.includes('no image link'))).toBe(true);
+        expect(result.warnings.some(w => w.includes('Story/EN/Act I/Chapter 1.md'))).toBe(true);
     });
 
     it('does not warn when the chapter references the legacy image explicitly', async () => {

--- a/mcp-ts/package-lock.json
+++ b/mcp-ts/package-lock.json
@@ -25,10 +25,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      },
-      "overrides": {
-        "hono": ">=4.12.25",
-        "vite": ">=8.0.16"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -126,12 +122,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -327,6 +323,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -344,6 +343,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -361,6 +363,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -378,6 +383,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -395,6 +403,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -412,6 +423,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1128,11 +1142,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -1152,9 +1167,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1338,9 +1353,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1465,9 +1480,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1493,9 +1508,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -1509,23 +1524,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -1544,9 +1559,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -1565,9 +1580,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -1586,9 +1601,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -1607,9 +1622,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -1628,13 +1643,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1649,13 +1667,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1670,13 +1691,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1691,13 +1715,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1712,9 +1739,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -1733,9 +1760,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -1801,12 +1828,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -1908,9 +1939,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -2007,9 +2038,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -2027,7 +2058,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2499,16 +2530,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/mcp-ts/package.json
+++ b/mcp-ts/package.json
@@ -42,7 +42,8 @@
   },
   "overrides": {
     "hono": ">=4.12.25",
-    "vite": ">=8.0.16"
+    "vite": ">=8.0.16",
+    "@hono/node-server": ">=2.0.5"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/obsidian-plugin/src/main.ts
+++ b/obsidian-plugin/src/main.ts
@@ -10,11 +10,15 @@
  */
 
 import { BINDERY_FOLDER, SETTINGS_FILENAME, upsertGlossaryRule, getDefaultLanguage, applyTypography, readWorkspaceSettings, type LanguageConfig } from '@bindery/core';
+import {
+    proposeLegacyImageMigration, applyLegacyImageMigration,
+    proposeLegacyCoverMigration, applyLegacyCoverMigration,
+} from '@bindery/merge';
 import { mergeBook, type OutputType } from './merge';
 import { formatFile } from './formatter';
 import { resolveBookRoot } from './exporter';
 import { setupAiFiles, ALL_SKILLS } from './ai-setup';
-import { readSettings, addDialectRule, addLanguage, findProbableUsWords } from './workspace';
+import { readSettings, writeSettings, addDialectRule, addLanguage, findProbableUsWords } from './workspace';
 import { BinderySettingsTab, DEFAULT_SETTINGS, type BinderySettings } from './settings-tab';
 import { App, Modal, Notice, Plugin, TFile } from 'obsidian';
 import type { Editor } from 'obsidian';
@@ -87,6 +91,59 @@ class TextPromptModal extends Modal {
         }
         this.resolved = true;
         this.onResolve(value);
+        this.close();
+    }
+}
+
+class ConfirmModal extends Modal {
+    private readonly titleText: string;
+    private readonly bodyText: string;
+    private readonly confirmLabel: string;
+    private readonly declineLabel: string;
+    private readonly onResolve: (_confirmed: boolean | null) => void;
+    private resolved = false;
+
+    constructor(
+        app: App,
+        titleText: string,
+        bodyText: string,
+        confirmLabel: string,
+        declineLabel: string,
+        onResolve: (_confirmed: boolean | null) => void
+    ) {
+        super(app);
+        this.titleText = titleText;
+        this.bodyText = bodyText;
+        this.confirmLabel = confirmLabel;
+        this.declineLabel = declineLabel;
+        this.onResolve = onResolve;
+    }
+
+    onOpen(): void {
+        this.titleEl.setText(this.titleText);
+        this.contentEl.empty();
+        this.contentEl.createEl('p', { text: this.bodyText });
+
+        const buttons = this.contentEl.createDiv({ cls: 'bindery-prompt-buttons' });
+        const confirmButton = buttons.createEl('button', { text: this.confirmLabel, cls: 'mod-cta' });
+        confirmButton.addEventListener('click', () => this.resolveAndClose(true));
+
+        const declineButton = buttons.createEl('button', { text: this.declineLabel });
+        declineButton.addEventListener('click', () => this.resolveAndClose(false));
+    }
+
+    onClose(): void {
+        if (!this.resolved) {
+            this.onResolve(null);
+        }
+    }
+
+    private resolveAndClose(confirmed: boolean): void {
+        if (this.resolved) {
+            return;
+        }
+        this.resolved = true;
+        this.onResolve(confirmed);
         this.close();
     }
 }
@@ -365,6 +422,74 @@ export default class BinderyPlugin extends Plugin {
         }
 
         this.addSettingTab(new BinderySettingsTab(this.app, this));
+
+        // Legacy image migration — implicit images/chapterN.jpg injection and the
+        // fixed Story/<lang>/cover.jpg convention were replaced by inline markdown
+        // links and an explicit coverImage setting; offer a one-time conversion.
+        void this.checkLegacyImageMigration();
+    }
+
+    private async checkLegacyImageMigration(): Promise<void> {
+        try {
+            const vaultPath = this.getVaultBasePath();
+            const bookRoot = resolveBookRoot(vaultPath, this.settings.bookRoot);
+            const wsSettings = readSettings(bookRoot);
+            if (!wsSettings || wsSettings.imageLinksMigrated) { return; }
+
+            const storyFolder = wsSettings.storyFolder ?? 'Story';
+            const languages: LanguageConfig[] = wsSettings.languages?.length
+                ? wsSettings.languages
+                : [{ code: 'EN', folderName: 'EN', chapterWord: 'Chapter', actPrefix: 'Act', prologueLabel: 'Prologue', epilogueLabel: 'Epilogue' }];
+            const chapterProposals = languages.flatMap(lang => proposeLegacyImageMigration(bookRoot, storyFolder, lang));
+            const coverProposals = proposeLegacyCoverMigration(bookRoot, storyFolder, languages);
+            if (chapterProposals.length === 0 && coverProposals.length === 0) { return; }
+
+            const parts: string[] = [];
+            if (chapterProposals.length > 0) {
+                parts.push(`${chapterProposals.length} chapter image(s) in images/ not referenced by a markdown link`);
+            }
+            if (coverProposals.length > 0) {
+                parts.push(`${coverProposals.length} cover image(s) still using the old Story/<lang>/cover.jpg location`);
+            }
+
+            const confirmed = await new Promise<boolean | null>((resolve) => {
+                new ConfirmModal(
+                    this.app,
+                    'Bindery: legacy images',
+                    `Found ${parts.join(' and ')}. These are no longer picked up implicitly at export — apply the explicit migration now?`,
+                    'Migrate',
+                    'Keep as-is',
+                    resolve
+                ).open();
+            });
+            if (confirmed === null) { return; }
+
+            if (confirmed) {
+                const changed = applyLegacyImageMigration(chapterProposals);
+                const coverApplied = applyLegacyCoverMigration(bookRoot, coverProposals);
+
+                const updated = readSettings(bookRoot);
+                if (updated?.languages) {
+                    for (const lang of updated.languages) {
+                        const newCover = coverApplied.get(lang.code);
+                        if (newCover) { lang.coverImage = newCover; }
+                    }
+                }
+                if (updated) {
+                    updated.imageLinksMigrated = true;
+                    writeSettings(bookRoot, updated);
+                }
+                this.notify(`Bindery: inserted image links in ${changed} file(s), moved ${coverApplied.size} cover image(s) to images/.`);
+            } else {
+                const updated = readSettings(bookRoot);
+                if (updated) {
+                    updated.imageLinksMigrated = true;
+                    writeSettings(bookRoot, updated);
+                }
+            }
+        } catch {
+            // Non-fatal: keep plugin load resilient.
+        }
     }
 
     private async mergeBook(outputTypes: OutputType[]): Promise<void> {
@@ -383,6 +508,11 @@ export default class BinderyPlugin extends Plugin {
 
             const names = result.outputs.map((p: string) => path.basename(p)).join(', ');
             this.notify(`Merged: ${names}`);
+            if (result.warnings.length > 0) {
+                const preview = result.warnings.slice(0, 2).join(' | ');
+                const more    = result.warnings.length > 2 ? ` (+${result.warnings.length - 2} more)` : '';
+                this.notify(`Merge warnings: ${preview}${more}`);
+            }
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             console.error(`✗ Merge failed: ${message}`);
@@ -530,7 +660,13 @@ export default class BinderyPlugin extends Plugin {
             const folderName = await this.promptString('Folder name:', code);
             if (!folderName) return;
 
-            addLanguage(bookRoot, code, folderName);
+            const coverImage = await this.promptOptional(
+                'Cover image path (relative to book root, blank for none):',
+                `images/${code.toUpperCase()}-cover.jpg`
+            );
+            if (coverImage === null) return;
+
+            addLanguage(bookRoot, code, folderName, undefined, undefined, coverImage);
             this.notify(`Added language: ${code}`);
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);

--- a/obsidian-plugin/src/merge.ts
+++ b/obsidian-plugin/src/merge.ts
@@ -61,6 +61,7 @@ export async function mergeBook(
         const filePrefix  = wsSettings?.mergeFilePrefix ?? 'Book';
         const author      = wsSettings?.author;
         const bookTitle   = getBookTitleForLang(wsSettings, language.code);
+        const coverImage  = wsSettings?.coverImage;
 
         const options: MergeOptionsCore = {
             root: bookRoot,
@@ -71,6 +72,7 @@ export async function mergeBook(
             includeSeparators: true,
             author,
             bookTitle,
+            coverImage,
             outputDir,
             filePrefix,
             pandocPath:      resolvePandocPath(settings),

--- a/obsidian-plugin/src/workspace.ts
+++ b/obsidian-plugin/src/workspace.ts
@@ -78,7 +78,8 @@ export function addLanguage(
     code: string,
     folderName: string,
     chapterWord?: string,
-    actPrefix?: string
+    actPrefix?: string,
+    coverImage?: string
 ): void {
     const settings = readSettings(bookRoot) || { languages: [] };
     settings.languages ??= [];
@@ -94,6 +95,7 @@ export function addLanguage(
         actPrefix: actPrefix ?? 'Act',
         prologueLabel: 'Prologue',
         epilogueLabel: 'Epilogue',
+        ...(coverImage?.trim() ? { coverImage: coverImage.trim() } : {}),
     });
 
     writeSettings(bookRoot, settings);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,30 @@
         "node": ">=18.0.0"
       }
     },
+    "bindery-core/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "bindery-core/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "bindery-merge": {
       "name": "@bindery/merge",
       "version": "0.1.0",
@@ -43,6 +67,30 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "bindery-merge/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "bindery-merge/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "mcp-ts": {
@@ -69,163 +117,34 @@
         "node": ">=18.0.0"
       }
     },
-    "mcp-ts/node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
-    "mcp-ts/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
+    "mcp-ts/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "mcp-ts/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
-    "mcp-ts/node_modules/ajv": {
-      "version": "8.18.0",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "mcp-ts/node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "mcp-ts/node_modules/cors": {
-      "version": "2.8.6",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "mcp-ts/node_modules/eventsource": {
-      "version": "3.0.7",
-      "license": "MIT",
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "mcp-ts/node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "mcp-ts/node_modules/fflate": {
-      "version": "0.8.2",
-      "license": "MIT"
-    },
-    "mcp-ts/node_modules/jose": {
-      "version": "6.2.2",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "mcp-ts/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    "mcp-ts/node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "license": "BSD-2-Clause"
-    },
-    "mcp-ts/node_modules/minisearch": {
-      "version": "7.2.0",
-      "license": "MIT"
-    },
-    "mcp-ts/node_modules/pkce-challenge": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "mcp-ts/node_modules/zod": {
-      "version": "4.3.6",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "mcp-ts/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
+        "node": ">=14.17"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -233,9 +152,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -243,13 +162,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -259,14 +178,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -792,9 +711,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -893,9 +812,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -905,7 +824,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
@@ -914,6 +833,23 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
@@ -944,6 +880,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -958,9 +901,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1008,6 +951,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1115,9 +1070,9 @@
       }
     },
     "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -1158,6 +1113,46 @@
       "license": "MIT",
       "dependencies": {
         "ret": "~0.1.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1295,6 +1290,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,6 +1310,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,6 +1330,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1346,6 +1350,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,6 +1370,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1380,6 +1390,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1531,9 +1544,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1551,16 +1564,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.19.0"
-      }
-    },
     "node_modules/@types/tern": {
       "version": "0.23.9",
       "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
@@ -1571,18 +1574,25 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/vscode": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1595,22 +1605,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1626,14 +1636,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1648,14 +1658,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1666,9 +1676,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1683,15 +1693,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1708,9 +1718,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1722,16 +1732,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1750,16 +1760,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1774,13 +1784,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1805,14 +1815,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.10",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1826,8 +1836,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1836,16 +1846,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1854,13 +1864,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1881,9 +1891,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1894,13 +1904,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.10",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1908,14 +1918,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1924,9 +1934,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1934,13 +1944,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.10",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1962,9 +1972,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1985,20 +1995,36 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-styles": {
@@ -2195,9 +2221,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
-      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2292,16 +2318,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -2472,10 +2498,27 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2661,9 +2704,9 @@
       "license": "MIT"
     },
     "node_modules/empathic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2680,9 +2723,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2762,6 +2805,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2781,9 +2843,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2809,16 +2871,16 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2857,15 +2919,18 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2936,9 +3001,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2947,8 +3012,8 @@
         "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3034,9 +3099,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3209,23 +3274,6 @@
         "eslint": ">=6.0.0"
       }
     },
-    "node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/eslint-plugin-json-schema-validator/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3242,13 +3290,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
-    },
-    "node_modules/eslint-plugin-json-schema-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
       "version": "8.0.7",
@@ -3409,20 +3450,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/eslint-plugin-obsidianmd/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -3544,6 +3571,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3584,6 +3628,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.5",
@@ -3694,10 +3745,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3748,11 +3820,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -3786,9 +3859,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -3818,6 +3891,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3885,9 +3964,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3950,18 +4029,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4201,9 +4283,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4213,9 +4295,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -4249,9 +4331,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4265,9 +4347,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4467,6 +4549,22 @@
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4798,6 +4896,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -4845,36 +4952,17 @@
         "ajv": "^8.0.0"
       }
     },
-    "node_modules/json-schema-migrate/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+    "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4974,9 +5062,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -4990,23 +5078,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -5025,9 +5113,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -5046,9 +5134,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -5067,9 +5155,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -5088,9 +5176,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -5109,13 +5197,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5130,13 +5221,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5151,13 +5245,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5172,13 +5269,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5193,9 +5293,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -5214,9 +5314,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -5288,13 +5388,13 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
-      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
+        "@babel/parser": "^7.29.3",
         "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
@@ -5325,12 +5425,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -5396,6 +5500,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
+    },
     "node_modules/module-replacements": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.11.0.tgz",
@@ -5455,9 +5565,9 @@
       }
     },
     "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5620,15 +5730,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -5670,13 +5783,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -5804,6 +5918,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5815,9 +5938,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -5835,7 +5958,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5889,12 +6012,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -5904,12 +6028,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -5998,14 +6126,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -6194,9 +6322,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6328,14 +6456,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -6433,9 +6561,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6493,19 +6621,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6515,16 +6644,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6647,9 +6776,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6657,9 +6786,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6856,18 +6985,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6877,9 +7006,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6891,16 +7020,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6934,9 +7063,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6969,16 +7098,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -7046,37 +7175,20 @@
         }
       }
     },
-    "node_modules/vite/node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -7104,12 +7216,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7244,14 +7356,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -7299,9 +7411,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7344,6 +7456,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "obsidian-plugin": {
       "name": "bindery-obsidian-plugin",
       "version": "0.1.0",
@@ -7365,6 +7495,30 @@
         "node": ">=18.0.0"
       }
     },
+    "obsidian-plugin/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "obsidian-plugin/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "vscode-ext": {
       "name": "bindery",
       "version": "0.0.0",
@@ -7382,10 +7536,29 @@
         "vscode": "^1.116.0"
       }
     },
-    "vscode-ext/node_modules/@types/vscode": {
-      "version": "1.116.0",
+    "vscode-ext/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "vscode-ext/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-obsidianmd": "^0.2.9"
   },
   "overrides": {
-    "qs": "^6.15.2"
+    "qs": "^6.15.2",
+    "@hono/node-server": "^2.0.5"
   }
 }

--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -18,6 +18,8 @@ import { execSync, spawnSync } from 'node:child_process'
 import { updateTypography }                    from './format';
 import {
     mergeBook, checkPandoc, getBuiltInUkReplacements,
+    proposeLegacyImageMigration, applyLegacyImageMigration,
+    proposeLegacyCoverMigration, applyLegacyCoverMigration,
     type LanguageConfig, type DialectConfig, type OutputType, type MergeOptions, type UkReplacement,
 } from './merge';
 import {
@@ -123,6 +125,7 @@ interface EffectiveConfig {
     formatOnSave:    boolean;
     author:          string | undefined;
     bookTitle:       string | undefined;
+    coverImage:      string | undefined;
     languages:       LanguageConfig[];
     pandocPath:      string;
     libreOfficePath: string;
@@ -144,6 +147,7 @@ function getEffectiveConfig(wsSettings: WorkspaceSettings | null): EffectiveConf
         bookTitle: (typeof wsSettings?.bookTitle === 'string' ? wsSettings.bookTitle : undefined)
                    || vsc.get<string>('bookTitle')
                    || undefined,
+        coverImage:      wsSettings?.coverImage || undefined,
         languages:       wsSettings?.languages
                          ?? vsc.get<LanguageConfig[]>('languages')
                          ?? [DEFAULT_LANGUAGE],
@@ -744,7 +748,7 @@ async function addLanguageCommand() {
     const storyFolder = wsSettings?.storyFolder ?? 'Story';
 
     const code = await vscode.window.showInputBox({
-        title:       'Bindery: Add Language (1/6) — Language code',
+        title:       'Bindery: Add Language (1/7) — Language code',
         prompt:      'Short code (2–3 uppercase letters)',
         placeHolder: 'FR  NL  DE  ES  IT  PT  …',
         validateInput: v => /^[A-Za-z]{2,3}$/.test(v.trim()) ? undefined : 'Enter 2–3 letters',
@@ -755,37 +759,44 @@ async function addLanguageCommand() {
     const preset = KNOWN_LANGUAGES[upper];
 
     const folderName = await vscode.window.showInputBox({
-        title:       'Bindery: Add Language (2/6) — Folder name',
+        title:       'Bindery: Add Language (2/7) — Folder name',
         prompt:      'Subfolder under Story/ for this language',
         value:       preset?.folderName ?? upper,
     });
     if (!folderName?.trim()) { return; }
 
     const chapterWord = await vscode.window.showInputBox({
-        title:       'Bindery: Add Language (3/6) — Chapter word',
+        title:       'Bindery: Add Language (3/7) — Chapter word',
         prompt:      'Word used for "Chapter" in this language',
         value:       preset?.chapterWord ?? 'Chapter',
     });
     if (!chapterWord?.trim()) { return; }
 
     const actPrefix = await vscode.window.showInputBox({
-        title:       'Bindery: Add Language (4/6) — Act prefix',
+        title:       'Bindery: Add Language (4/7) — Act prefix',
         prompt:      'Word used for "Act" in this language',
         value:       preset?.actPrefix ?? 'Act',
     });
     if (!actPrefix?.trim()) { return; }
 
     const prologueLabel = await vscode.window.showInputBox({
-        title:       'Bindery: Add Language (5/6) — Prologue label',
+        title:       'Bindery: Add Language (5/7) — Prologue label',
         value:       preset?.prologueLabel ?? 'Prologue',
     });
     if (!prologueLabel?.trim()) { return; }
 
     const epilogueLabel = await vscode.window.showInputBox({
-        title:       'Bindery: Add Language (6/6) — Epilogue label',
+        title:       'Bindery: Add Language (6/7) — Epilogue label',
         value:       preset?.epilogueLabel ?? 'Epilogue',
     });
     if (!epilogueLabel?.trim()) { return; }
+
+    const coverImage = await vscode.window.showInputBox({
+        title:       'Bindery: Add Language (7/7) — Cover image path',
+        prompt:      'Path to this language\'s cover image, relative to the book root (leave blank for none)',
+        value:       `images/${upper}-cover.jpg`,
+    });
+    if (coverImage === undefined) { return; }
 
     const newLang: LanguageConfig = {
         code:          upper,
@@ -794,6 +805,7 @@ async function addLanguageCommand() {
         actPrefix:     actPrefix.trim(),
         prologueLabel: prologueLabel.trim(),
         epilogueLabel: epilogueLabel.trim(),
+        ...(coverImage.trim() ? { coverImage: coverImage.trim() } : {}),
     };
 
     // Update settings.json
@@ -996,6 +1008,7 @@ function buildMergeOptions(
         includeSeparators: true,
         author:          cfg.author,
         bookTitle,
+        coverImage:      cfg.coverImage,
         outputDir:       cfg.mergedOutputDir,
         filePrefix:      cfg.mergeFilePrefix,
         pandocPath:      cfg.pandocPath,
@@ -1750,6 +1763,67 @@ export function activate(context: vscode.ExtensionContext) {
                 }
             } catch {
                 // Non-fatal: keep activation resilient if MCP tools are unavailable.
+            }
+        })();
+    }
+
+    // Legacy image migration — implicit images/chapterN.jpg injection and the
+    // fixed Story/<lang>/cover.jpg convention were replaced by inline markdown
+    // links and an explicit coverImage setting; offer a one-time conversion.
+    if (root && fs.existsSync(getSettingsPath(root))) {
+        void (async () => {
+            try {
+                const settings = readWorkspaceSettings(root);
+                if (!settings || settings.imageLinksMigrated) { return; }
+                const storyFolder = settings.storyFolder ?? 'Story';
+                const languages = settings.languages?.length ? settings.languages : [DEFAULT_LANGUAGE];
+                const chapterProposals = languages.flatMap(lang => proposeLegacyImageMigration(root, storyFolder, lang));
+                const coverProposals = proposeLegacyCoverMigration(root, storyFolder, languages);
+                if (chapterProposals.length === 0 && coverProposals.length === 0) { return; }
+
+                const parts: string[] = [];
+                if (chapterProposals.length > 0) {
+                    parts.push(`${chapterProposals.length} chapter image(s) in images/ not referenced by a markdown link`);
+                }
+                if (coverProposals.length > 0) {
+                    parts.push(`${coverProposals.length} cover image(s) still using the old Story/<lang>/cover.jpg location`);
+                }
+
+                const action = await vscode.window.showInformationMessage(
+                    `Bindery: found ${parts.join(' and ')}. ` +
+                    'These are no longer picked up implicitly at export — apply the explicit migration now?',
+                    'Migrate',
+                    'Keep as-is'
+                );
+                if (action === undefined) { return; }
+
+                if (action === 'Migrate') {
+                    const changed = applyLegacyImageMigration(chapterProposals);
+                    const coverApplied = applyLegacyCoverMigration(root, coverProposals);
+
+                    const updated = readWorkspaceSettings(root);
+                    if (updated?.languages) {
+                        for (const lang of updated.languages) {
+                            const newCover = coverApplied.get(lang.code);
+                            if (newCover) { lang.coverImage = newCover; }
+                        }
+                    }
+                    if (updated) {
+                        updated.imageLinksMigrated = true;
+                        fs.writeFileSync(getSettingsPath(root), JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+                    }
+                    vscode.window.showInformationMessage(
+                        `Bindery: inserted image links in ${changed} file(s), moved ${coverApplied.size} cover image(s) to images/.`
+                    );
+                } else {
+                    const updated = readWorkspaceSettings(root);
+                    if (updated) {
+                        updated.imageLinksMigrated = true;
+                        fs.writeFileSync(getSettingsPath(root), JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+                    }
+                }
+            } catch {
+                // Non-fatal: keep activation resilient.
             }
         })();
     }

--- a/vscode-ext/src/merge.ts
+++ b/vscode-ext/src/merge.ts
@@ -17,6 +17,12 @@ export {
     getPandocOutputFormats,
     clearPandocCapabilityCache,
     getBuiltInUkReplacements,
+    type LegacyImageProposal,
+    proposeLegacyImageMigration,
+    applyLegacyImageMigration,
+    type LegacyCoverProposal,
+    proposeLegacyCoverMigration,
+    applyLegacyCoverMigration,
 } from '@bindery/merge';
 
 // Re-export types from bindery-core for backward compatibility


### PR DESCRIPTION
- Implement unit tests for `resolveCoverImage()` to verify cover image resolution logic, including explicit settings and legacy fallback.
- Create unit tests for `images.ts` to validate image link rewriting, wikilink stripping, and portable markdown export.
- Add tests for legacy image migration functions in `legacy-images.ts`, ensuring proper proposals and application of migrations for chapter and cover images.
- Introduce integration tests for `mergeBook()` to check inline image handling and ensure correct copying and linking of images in merged output.
- Update the Obsidian plugin to prompt for legacy image migration, applying changes to settings and notifying users of the migration results.
- Enhance the VSCode extension to support legacy image migration, providing user feedback and updating workspace settings accordingly.